### PR TITLE
Rename instances of 'eveeve' to 'evame' in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,13 +1,13 @@
 databases:
-  - name: eveeve-db
+  - name: evame-db
     plan: starter
     region: singapore
 
 services:
 - type: web
-  name: eveeve
+  name: evame
   runtime: node
-  repo: https://github.com/ttizze/eveeve
+  repo: https://github.com/ttizze/evame
   branch: main
   plan: starter
   region: singapore
@@ -17,21 +17,22 @@ services:
   envVars:
     - key: DATABASE_URL
       fromDatabase:
-        name: eveeve-db
+        name: evame-db
         property: connectionString
     - key: REDIS_HOST
       fromService:
         type: redis
-        name: eveeve-redis
+        name: evame-redis
         property: host
     - key: REDIS_PORT
       fromService:
         type: redis
-        name: eveeve-redis
+        name: evame-redis
         property: port
 
 - type: redis
-  name: eveeve-redis
+  name: evame-redis
   plan: free
   region: singapore
   ipAllowList: []
+


### PR DESCRIPTION
This pull request updates the `render.yaml` file to rename all instances of 'eveeve' to 'evame', including database and service names, ensuring consistency across the configuration.