### PR TITLE
Add title argument to rehypeAddDataId and enhance source_texts tests

### DIFF
--- a/web/app/routes/$userName+/page+/$slug+/edit/functions/mutations.server.ts
+++ b/web/app/routes/$userName+/page+/$slug+/edit/functions/mutations.server.ts
@@ -1,5 +1,4 @@
 import { prisma } from "~/utils/prisma";
-import { generateHashForText } from "../utils/generateHashForText";
 
 export async function upsertPageWithHtml(
 	pageSlug: string,
@@ -24,25 +23,9 @@ export async function upsertPageWithHtml(
 export async function upsertTitle(pageSlug: string, title: string) {
 	const page = await prisma.page.findUnique({ where: { slug: pageSlug } });
 	if (!page) return;
-	const titleHash = generateHashForText(title, 0);
 	await prisma.page.update({
 		where: { id: page.id },
 		data: { title: title },
-	});
-	return await prisma.sourceText.upsert({
-		where: {
-			pageId_textAndOccurrenceHash: {
-				pageId: page.id,
-				textAndOccurrenceHash: titleHash,
-			},
-		},
-		update: { text: title },
-		create: {
-			pageId: page.id,
-			textAndOccurrenceHash: titleHash,
-			text: title,
-			number: 0,
-		},
 	});
 }
 

--- a/web/app/routes/$userName+/page+/$slug+/edit/utils/processHtmlContent.test.ts
+++ b/web/app/routes/$userName+/page+/$slug+/edit/utils/processHtmlContent.test.ts
@@ -248,7 +248,7 @@ describe("processHtmlContent", () => {
 			<p>Line B</p>
 			<p>Line C</p>
 		`;
-	
+
 		const user = await prisma.user.upsert({
 			where: { id: 13 },
 			create: {
@@ -260,46 +260,46 @@ describe("processHtmlContent", () => {
 			},
 			update: {},
 		});
-	
+
 		// 初回処理
 		await processHtmlContent(title, htmlInput, pageSlug, user.id, "en", true);
-	
+
 		const dbPage1 = await prisma.page.findUnique({
 			where: { slug: pageSlug },
 			include: { sourceTexts: true },
 		});
 		expect(dbPage1).not.toBeNull();
 		if (!dbPage1) return;
-	
+
 		// 初回処理時のIDを記憶
 		const originalTextIdMap = new Map<string, number>();
 		for (const st of dbPage1.sourceTexts) {
 			originalTextIdMap.set(st.text, st.id);
 		}
 		expect(originalTextIdMap.size).toBeGreaterThanOrEqual(3);
-	
+
 		// 変更なしで再度同一HTMLを処理
 		await processHtmlContent(title, htmlInput, pageSlug, user.id, "en", true);
-	
+
 		const dbPage2 = await prisma.page.findUnique({
 			where: { slug: pageSlug },
 			include: { sourceTexts: true },
 		});
 		expect(dbPage2).not.toBeNull();
 		if (!dbPage2) return;
-	
+
 		// 再処理後のIDマッピングを取得
 		const afterTextIdMap = new Map<string, number>();
 		for (const st of dbPage2.sourceTexts) {
 			afterTextIdMap.set(st.text, st.id);
 		}
-	
+
 		// 全てのテキストでIDが変わっていないことを確認
 		for (const [text, originalId] of originalTextIdMap.entries()) {
 			console.log(text, originalId);
 			expect(afterTextIdMap.get(text)).toBe(originalId);
 		}
-	
+
 		// source_textsの数が増減していないこと（無駄な消去がないこと）
 		expect(dbPage2.sourceTexts.length).toBe(dbPage1.sourceTexts.length);
 	});

--- a/web/app/routes/$userName+/page+/$slug+/edit/utils/processHtmlContent.ts
+++ b/web/app/routes/$userName+/page+/$slug+/edit/utils/processHtmlContent.ts
@@ -42,7 +42,7 @@ function extractTextFromHAST(node: Parent): string {
 	});
 	return result;
 }
-export function rehypeAddDataId(pageId: number): Plugin<[], Root> {
+export function rehypeAddDataId(pageId: number, title: string): Plugin<[], Root> {
 	return function attacher() {
 		return async (tree: Root, file: VFile) => {
 			const textOccurrenceMap = new Map<string, number>();
@@ -74,11 +74,18 @@ export function rehypeAddDataId(pageId: number): Plugin<[], Root> {
 				}
 			});
 
+
 			const allTextsForDb = blocks.map((block, index) => ({
 				text: block.text,
 				textAndOccurrenceHash: block.textAndOccurrenceHash,
 				number: index + 1,
-			}));
+			}))
+	
+			allTextsForDb.push({
+				text: title,
+				textAndOccurrenceHash: generateHashForText(title, 0),
+				number: 0,
+			});
 
 			const hashToId = await synchronizePageSourceTexts(pageId, allTextsForDb);
 
@@ -127,7 +134,7 @@ export async function processHtmlContent(
 		.use(rehypeRemark) // HAST→MDAST
 		.use(remarkGfm) // GFM拡張
 		.use(remarkRehype, { allowDangerousHtml: true }) // MDAST→HAST
-		.use(rehypeAddDataId(page.id))
+		.use(rehypeAddDataId(page.id, title))
 		.use(rehypeRaw) // 生HTMLを処理
 		.use(rehypeStringify, { allowDangerousHtml: true }) // HAST→HTML
 		.process(htmlInput);

--- a/web/app/routes/$userName+/page+/$slug+/edit/utils/processHtmlContent.ts
+++ b/web/app/routes/$userName+/page+/$slug+/edit/utils/processHtmlContent.ts
@@ -42,7 +42,10 @@ function extractTextFromHAST(node: Parent): string {
 	});
 	return result;
 }
-export function rehypeAddDataId(pageId: number, title: string): Plugin<[], Root> {
+export function rehypeAddDataId(
+	pageId: number,
+	title: string,
+): Plugin<[], Root> {
 	return function attacher() {
 		return async (tree: Root, file: VFile) => {
 			const textOccurrenceMap = new Map<string, number>();
@@ -74,13 +77,12 @@ export function rehypeAddDataId(pageId: number, title: string): Plugin<[], Root>
 				}
 			});
 
-
 			const allTextsForDb = blocks.map((block, index) => ({
 				text: block.text,
 				textAndOccurrenceHash: block.textAndOccurrenceHash,
 				number: index + 1,
-			}))
-	
+			}));
+
 			allTextsForDb.push({
 				text: title,
 				textAndOccurrenceHash: generateHashForText(title, 0),

--- a/web/scripts/processMarkdownContent.ts
+++ b/web/scripts/processMarkdownContent.ts
@@ -28,7 +28,7 @@ export async function processMarkdownContent(
 	const file = await remark()
 		.use(remarkGfm)
 		.use(remarkRehype)
-		.use(rehypeAddDataId(page.id))
+		.use(rehypeAddDataId(page.id, title))
 		.use(rehypeRaw)
 		.use(rehypeStringify, { allowDangerousHtml: true })
 		.process(body);


### PR DESCRIPTION
This pull request introduces a title parameter to the rehypeAddDataId function, allowing it to handle titles more effectively during HTML processing. Additionally, a new test has been added to ensure that when the same HTML is processed again without edits, the existing source_texts are preserved, confirming the integrity of the data. This enhancement improves the overall reliability of the content processing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTML processing now incorporates title data for better database synchronization.
	- New test case added to ensure stability of `source_texts` IDs during repeated HTML processing.

- **Bug Fixes**
	- Simplified title management by removing unnecessary hash generation in title handling.

- **Documentation**
	- Updated function signatures to reflect changes in parameters and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->