### PR TITLE
Make textAndOccurrenceHash field mandatory in SourceText model

### DIFF
--- a/web/app/routes/$userName+/index.test.tsx
+++ b/web/app/routes/$userName+/index.test.tsx
@@ -32,6 +32,7 @@ describe("UserProfile", () => {
 								create: {
 									number: 0,
 									text: "Public Page",
+									textAndOccurrenceHash: "hash0",
 								},
 							},
 						},
@@ -43,6 +44,7 @@ describe("UserProfile", () => {
 								create: {
 									number: 0,
 									text: "Private Page",
+									textAndOccurrenceHash: "hash1",
 								},
 							},
 						},
@@ -52,8 +54,9 @@ describe("UserProfile", () => {
 							content: "This is a test content3",
 							sourceTexts: {
 								create: {
-									number: 0,
+									number: 0,	
 									text: "Archived Page",
+									textAndOccurrenceHash: "hash2",
 								},
 							},
 						},

--- a/web/app/routes/$userName+/index.test.tsx
+++ b/web/app/routes/$userName+/index.test.tsx
@@ -54,7 +54,7 @@ describe("UserProfile", () => {
 							content: "This is a test content3",
 							sourceTexts: {
 								create: {
-									number: 0,	
+									number: 0,
 									text: "Archived Page",
 									textAndOccurrenceHash: "hash2",
 								},

--- a/web/app/routes/$userName+/page+/$slug+/edit/_edit.test.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/edit/_edit.test.tsx
@@ -67,10 +67,18 @@ describe("EditPage", () => {
 								"<p data-number='1'>hello</p><p data-number='2'>world</p><p data-number='3'>This is a test content</p>",
 							sourceTexts: {
 								create: [
-									{ number: 0, text: "Test Title", textAndOccurrenceHash: "hash0" },
+									{
+										number: 0,
+										text: "Test Title",
+										textAndOccurrenceHash: "hash0",
+									},
 									{ number: 1, text: "hello", textAndOccurrenceHash: "hash1" },
 									{ number: 2, text: "world", textAndOccurrenceHash: "hash2" },
-									{ number: 3, text: "This is a test content", textAndOccurrenceHash: "hash3" },
+									{
+										number: 3,
+										text: "This is a test content",
+										textAndOccurrenceHash: "hash3",
+									},
 								],
 							},
 						},

--- a/web/app/routes/$userName+/page+/$slug+/edit/_edit.test.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/edit/_edit.test.tsx
@@ -67,10 +67,10 @@ describe("EditPage", () => {
 								"<p data-number='1'>hello</p><p data-number='2'>world</p><p data-number='3'>This is a test content</p>",
 							sourceTexts: {
 								create: [
-									{ number: 0, text: "Test Title" },
-									{ number: 1, text: "hello" },
-									{ number: 2, text: "world" },
-									{ number: 3, text: "This is a test content" },
+									{ number: 0, text: "Test Title", textAndOccurrenceHash: "hash0" },
+									{ number: 1, text: "hello", textAndOccurrenceHash: "hash1" },
+									{ number: 2, text: "world", textAndOccurrenceHash: "hash2" },
+									{ number: 3, text: "This is a test content", textAndOccurrenceHash: "hash3" },
 								],
 							},
 						},

--- a/web/prisma/migrations/20241217095050_/migration.sql
+++ b/web/prisma/migrations/20241217095050_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `text_and_occurrence_hash` on table `source_texts` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "source_texts" ALTER COLUMN "text_and_occurrence_hash" SET NOT NULL;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -170,7 +170,7 @@ model SourceText {
   id             Int             @id @default(autoincrement())
   text           String
   number         Int
-  textAndOccurrenceHash String? @map("text_and_occurrence_hash")
+  textAndOccurrenceHash String @map("text_and_occurrence_hash")
   translateTexts TranslateText[]
   page           Page            @relation(fields: [pageId], references: [id], onDelete: Cascade)
   pageId         Int             @map("page_id")


### PR DESCRIPTION
This pull request updates the SourceText model to make the `textAndOccurrenceHash` field required, along with adding a migration to enforce this change. Additionally, tests for UserProfile and EditPage have been updated to include the `textAndOccurrenceHash` field for sourceTexts, ensuring consistency across the application.