### PR TITLE
Update user profile links to include '/user/' prefix

### DIFF
--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/TranslationSection.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/TranslationSection.tsx
@@ -47,7 +47,7 @@ export function TranslationSection({
 				<>
 					<div className="flex items-center justify-end">
 						<Link
-							to={`/${bestTranslationWithVote?.user.userName}`}
+							to={`/user/${bestTranslationWithVote?.user.userName}`}
 							className="!no-underline mr-2"
 						>
 							<p className="text-sm text-gray-500 text-right flex justify-end items-center">

--- a/web/app/routes/resources+/header.tsx
+++ b/web/app/routes/resources+/header.tsx
@@ -25,7 +25,7 @@ export async function action({ request }: ActionFunctionArgs) {
 		const user = await authenticator.authenticate("google", request);
 
 		if (user) {
-			return redirect(`/${user.userName}`);
+			return redirect(`/user/${user.userName}`);
 		}
 
 		return redirect("/auth/login");

--- a/web/app/routes/resources+/translation-list-item.tsx
+++ b/web/app/routes/resources+/translation-list-item.tsx
@@ -81,7 +81,7 @@ export function TranslationListItem({
 			</div>
 			<div className="flex items-center justify-end">
 				<Link
-					to={`/${translation.user.userName}`}
+					to={`/user/${translation.user.userName}`}
 					className="!no-underline mr-2"
 				>
 					<p className="text-sm text-gray-500 text-right flex justify-end items-center  ">

--- a/web/app/routes/sitemap[.]xml.ts
+++ b/web/app/routes/sitemap[.]xml.ts
@@ -26,12 +26,12 @@ export const handle: SEOHandle = {
 		]);
 
 		const pageEntries = pages.map((page) => ({
-			route: `/${page.user.userName}/page/${page.slug}`,
+			route: `/user/${page.user.userName}/page/${page.slug}`,
 			lastmod: page.updatedAt.toISOString(),
 		}));
 
 		const userEntries = users.map((user) => ({
-			route: `/${user.userName}`,
+			route: `/user/${user.userName}`,
 			lastmod: user.updatedAt.toISOString(),
 		}));
 


### PR DESCRIPTION
This pull request modifies the routing for user profile links throughout the application. All instances of user profile URLs have been updated to include the '/user/' prefix, ensuring consistency and clarity in navigation. This change affects both the translation section and user authentication redirects.