### PR TITLE
Replace Link with LocaleLink for localization support

### DIFF
--- a/web/app/components/BaseHeaderLayout.tsx
+++ b/web/app/components/BaseHeaderLayout.tsx
@@ -1,10 +1,9 @@
-import { Link } from "@remix-run/react";
-import { LocaleLink } from "~/components/LocaleLink";
-import { NavLocaleLink } from "~/components/NavLocaleLink";
-import { Form, NavLink } from "@remix-run/react";
+import { Form } from "@remix-run/react";
 import { LogOutIcon, SettingsIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { ModeToggle } from "~/components/ModeToggle";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import {
 	DropdownMenu,

--- a/web/app/components/BaseHeaderLayout.tsx
+++ b/web/app/components/BaseHeaderLayout.tsx
@@ -1,4 +1,6 @@
 import { Link } from "@remix-run/react";
+import { LocaleLink } from "~/components/LocaleLink";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Form, NavLink } from "@remix-run/react";
 import { LogOutIcon, SettingsIcon } from "lucide-react";
 import type { ReactNode } from "react";
@@ -30,14 +32,14 @@ export function BaseHeaderLayout({
 		<header className="z-10 w-full">
 			<div className="max-w-7xl mx-auto py-2 md:py-4 px-2 md:px-6 lg:px-8 flex justify-between items-center">
 				<div className="flex items-center gap-4">
-					<Link to="/home" className="flex items-center">
+					<LocaleLink to="/home" className="flex items-center">
 						<img
 							src="/logo.svg"
 							alt="Evame"
 							className="h-8 w-20 dark:invert"
 							aria-label="Evame Logo"
 						/>
-					</Link>
+					</LocaleLink>
 					{leftExtra}
 				</div>
 				<div className="flex items-center gap-4">
@@ -57,7 +59,7 @@ export function BaseHeaderLayout({
 							</DropdownMenuTrigger>
 							<DropdownMenuContent className="m-2 p-0 rounded-xl min-w-40">
 								<DropdownMenuItem asChild>
-									<NavLink
+									<NavLocaleLink
 										to={`/user/${currentUser.userName}`}
 										className={({ isPending }) =>
 											isPending
@@ -71,11 +73,11 @@ export function BaseHeaderLayout({
 												@{currentUser.userName}
 											</span>
 										</div>
-									</NavLink>
+									</NavLocaleLink>
 								</DropdownMenuItem>
 								<DropdownMenuSeparator className="my-0" />
 								<DropdownMenuItem asChild>
-									<NavLink
+									<NavLocaleLink
 										to={`/user/${currentUser.userName}/page-management`}
 										className={({ isPending }) =>
 											isPending
@@ -85,7 +87,7 @@ export function BaseHeaderLayout({
 									>
 										<SettingsIcon className="w-4 h-4" />
 										Page Management
-									</NavLink>
+									</NavLocaleLink>
 								</DropdownMenuItem>
 								<DropdownMenuItem asChild>
 									<ModeToggle />

--- a/web/app/components/LocaleLink.tsx
+++ b/web/app/components/LocaleLink.tsx
@@ -2,9 +2,9 @@
 import { Link, useMatches } from "@remix-run/react";
 
 function useRootData() {
-  const matches = useMatches();
-  const rootMatch = matches.find((match) => match.id === "root");
-  return rootMatch?.data as { locale: string } | undefined;
+	const matches = useMatches();
+	const rootMatch = matches.find((match) => match.id === "root");
+	return rootMatch?.data as { locale: string } | undefined;
 }
 
 export function LocaleLink({
@@ -21,5 +21,9 @@ export function LocaleLink({
 
 	const path = `/${locale}${to}`;
 
-	return <Link to={path} className={className}>{children}</Link>;
+	return (
+		<Link to={path} className={className}>
+			{children}
+		</Link>
+	);
 }

--- a/web/app/components/LocaleLink.tsx
+++ b/web/app/components/LocaleLink.tsx
@@ -1,0 +1,25 @@
+// LocaleLink.tsx
+import { Link, useMatches } from "@remix-run/react";
+
+function useRootData() {
+  const matches = useMatches();
+  const rootMatch = matches.find((match) => match.id === "root");
+  return rootMatch?.data as { locale: string } | undefined;
+}
+
+export function LocaleLink({
+	to,
+	children,
+	className,
+}: {
+	to: string;
+	children: React.ReactNode;
+	className?: string;
+}) {
+	const rootData = useRootData();
+	const locale = rootData?.locale ?? "en";
+
+	const path = `/${locale}${to}`;
+
+	return <Link to={path} className={className}>{children}</Link>;
+}

--- a/web/app/components/NavLocaleLink.tsx
+++ b/web/app/components/NavLocaleLink.tsx
@@ -1,0 +1,37 @@
+import { NavLink, useMatches, type NavLinkProps } from "@remix-run/react";
+
+function useRootData() {
+  const matches = useMatches();
+  const rootMatch = matches.find((match) => match.id === "root");
+  return rootMatch?.data as { locale?: string } | undefined;
+}
+
+// NavLinkProps を継承
+type NavLocaleLinkProps = Omit<NavLinkProps, "to"> & {
+  to: string;
+};
+
+export function NavLocaleLink({
+  to,
+  className,
+  children,
+  ...rest
+}: NavLocaleLinkProps) {
+  const rootData = useRootData();
+  const locale = rootData?.locale ?? "en";
+
+  // 先頭のスラッシュを削除したうえで "/:locale" を付与
+  const normalized = to.startsWith("/") ? to.slice(1) : to;
+  const path = `/${locale}/${normalized}`;
+
+  return (
+    <NavLink
+      to={path}
+      // className が「文字列」or「コールバック」どちらでもOK
+      className={className}
+      {...rest}
+    >
+      {children}
+    </NavLink>
+  );
+}

--- a/web/app/components/NavLocaleLink.tsx
+++ b/web/app/components/NavLocaleLink.tsx
@@ -1,37 +1,37 @@
-import { NavLink, useMatches, type NavLinkProps } from "@remix-run/react";
+import { NavLink, type NavLinkProps, useMatches } from "@remix-run/react";
 
 function useRootData() {
-  const matches = useMatches();
-  const rootMatch = matches.find((match) => match.id === "root");
-  return rootMatch?.data as { locale?: string } | undefined;
+	const matches = useMatches();
+	const rootMatch = matches.find((match) => match.id === "root");
+	return rootMatch?.data as { locale?: string } | undefined;
 }
 
 // NavLinkProps を継承
 type NavLocaleLinkProps = Omit<NavLinkProps, "to"> & {
-  to: string;
+	to: string;
 };
 
 export function NavLocaleLink({
-  to,
-  className,
-  children,
-  ...rest
+	to,
+	className,
+	children,
+	...rest
 }: NavLocaleLinkProps) {
-  const rootData = useRootData();
-  const locale = rootData?.locale ?? "en";
+	const rootData = useRootData();
+	const locale = rootData?.locale ?? "en";
 
-  // 先頭のスラッシュを削除したうえで "/:locale" を付与
-  const normalized = to.startsWith("/") ? to.slice(1) : to;
-  const path = `/${locale}/${normalized}`;
+	// 先頭のスラッシュを削除したうえで "/:locale" を付与
+	const normalized = to.startsWith("/") ? to.slice(1) : to;
+	const path = `/${locale}/${normalized}`;
 
-  return (
-    <NavLink
-      to={path}
-      // className が「文字列」or「コールバック」どちらでもOK
-      className={className}
-      {...rest}
-    >
-      {children}
-    </NavLink>
-  );
+	return (
+		<NavLink
+			to={path}
+			// className が「文字列」or「コールバック」どちらでもOK
+			className={className}
+			{...rest}
+		>
+			{children}
+		</NavLink>
+	);
 }

--- a/web/app/components/PageCard.tsx
+++ b/web/app/components/PageCard.tsx
@@ -12,7 +12,7 @@ import {
 import { PageActionsDropdown } from "~/routes/$locale+/user.$userName+/components/PageActionsDropdown";
 import { LikeButton } from "~/routes/resources+/like-button";
 import type { PageCardType } from "~/routes/types";
-
+import { LocaleLink } from "~/components/LocaleLink";
 type PageCardProps = {
 	pageCard: PageCardType;
 	pageLink: string;
@@ -43,17 +43,17 @@ export function PageCard({
 				</div>
 			)}
 			<CardHeader>
-				<Link to={pageLink} className="block">
+				<LocaleLink to={pageLink} className="block">
 					<CardTitle className="flex items-center pr-3 break-all overflow-wrap-anywhere">
 						{!pageCard.isPublished && <Lock className="h-4 w-4 mr-2" />}
 						{pageCard.title}
 					</CardTitle>
 					<CardDescription>{pageCard.createdAt}</CardDescription>
-				</Link>
+				</LocaleLink>
 			</CardHeader>
 			<CardContent>
 				<div className="flex justify-between items-center">
-					<Link to={userLink} className="flex items-center">
+					<LocaleLink to={userLink} className="flex items-center">
 						<Avatar className="w-6 h-6 mr-2">
 							<AvatarImage
 								src={pageCard.user.icon}
@@ -66,7 +66,7 @@ export function PageCard({
 						<span className="text-sm text-gray-600">
 							{pageCard.user.displayName}
 						</span>
-					</Link>
+					</LocaleLink>
 
 					<LikeButton
 						liked={pageCard.likePages.length > 0}

--- a/web/app/components/PageCard.tsx
+++ b/web/app/components/PageCard.tsx
@@ -1,6 +1,5 @@
-// PageCard.tsx
-import { Link } from "@remix-run/react";
 import { Lock } from "lucide-react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import {
 	Card,
@@ -12,7 +11,6 @@ import {
 import { PageActionsDropdown } from "~/routes/$locale+/user.$userName+/components/PageActionsDropdown";
 import { LikeButton } from "~/routes/resources+/like-button";
 import type { PageCardType } from "~/routes/types";
-import { LocaleLink } from "~/components/LocaleLink";
 type PageCardProps = {
 	pageCard: PageCardType;
 	pageLink: string;

--- a/web/app/routes/$locale+/auth/login/route.tsx
+++ b/web/app/routes/$locale+/auth/login/route.tsx
@@ -7,6 +7,7 @@ import { useLocation } from "@remix-run/react";
 import { useNavigation } from "@remix-run/react";
 import { CheckCircle } from "lucide-react";
 import { z } from "zod";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
@@ -15,7 +16,6 @@ import { Separator } from "~/components/ui/separator";
 import { sessionStorage } from "~/utils/session.server";
 import { authenticator } from "../../../../utils/auth.server";
 import { GoogleForm } from "../../../resources+/google-form";
-import { LocaleLink } from "~/components/LocaleLink";
 const loginSchema = z.object({
 	email: z.string().email("Please enter a valid email address"),
 });

--- a/web/app/routes/$locale+/auth/login/route.tsx
+++ b/web/app/routes/$locale+/auth/login/route.tsx
@@ -5,7 +5,6 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { Form, useActionData, useLoaderData } from "@remix-run/react";
 import { useLocation } from "@remix-run/react";
 import { useNavigation } from "@remix-run/react";
-import { Link } from "@remix-run/react";
 import { CheckCircle } from "lucide-react";
 import { z } from "zod";
 import { Button } from "~/components/ui/button";
@@ -16,7 +15,7 @@ import { Separator } from "~/components/ui/separator";
 import { sessionStorage } from "~/utils/session.server";
 import { authenticator } from "../../../../utils/auth.server";
 import { GoogleForm } from "../../../resources+/google-form";
-
+import { LocaleLink } from "~/components/LocaleLink";
 const loginSchema = z.object({
 	email: z.string().email("Please enter a valid email address"),
 });
@@ -130,13 +129,13 @@ export default function LoginPage() {
 					</Form>
 					<div className="text-center text-sm text-gray-500 my-2">
 						Login means you agree to our{" "}
-						<Link to="/terms" className="underline">
+						<LocaleLink to="/terms" className="underline">
 							Terms of Service
-						</Link>{" "}
+						</LocaleLink>{" "}
 						and{" "}
-						<Link to="/privacy" className="underline">
+						<LocaleLink to="/privacy" className="underline">
 							Privacy Policy
-						</Link>
+						</LocaleLink>
 					</div>
 				</CardContent>
 			</Card>

--- a/web/app/routes/$locale+/privacy.tsx
+++ b/web/app/routes/$locale+/privacy.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@remix-run/react";
+import { LocaleLink } from "~/components/LocaleLink";
 
 export default function PrivacyPolicyPage() {
 	return (
@@ -99,9 +99,9 @@ export default function PrivacyPolicyPage() {
 				</section>
 
 				<div className="mt-8">
-					<Link to="/" className="text-blue-600 hover:underline">
+					<LocaleLink to="/" className="text-blue-600 hover:underline">
 						Return to Home
-					</Link>
+					</LocaleLink>
 				</div>
 			</main>
 		</div>

--- a/web/app/routes/$locale+/search/route.tsx
+++ b/web/app/routes/$locale+/search/route.tsx
@@ -3,13 +3,13 @@ import { getZodConstraint, parseWithZod } from "@conform-to/zod";
 import type { ActionFunctionArgs } from "@remix-run/node";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { useActionData, useNavigation } from "@remix-run/react";
-import { Link } from "@remix-run/react";
 import { Form } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { authenticator } from "~/utils/auth.server";
+import { LocaleLink } from "~/components/LocaleLink";
 import { searchTitle } from "./functions/queries.server";
 
 export const meta: MetaFunction = () => {
@@ -79,12 +79,12 @@ export default function Search() {
 										key={result.id}
 										className="hover:bg-gray-300 dark:hover:bg-gray-700 transition duration-150 rounded-lg"
 									>
-										<Link
+										<LocaleLink
 											to={`/user/${result.user.userName}/page/${encodeURIComponent(result.slug)}`}
 											className="block p-2 text-inherit no-underline"
 										>
 											<h3 className="font-bold">{result.title}</h3>
-										</Link>
+										</LocaleLink>
 									</li>
 								))}
 							</ul>

--- a/web/app/routes/$locale+/search/route.tsx
+++ b/web/app/routes/$locale+/search/route.tsx
@@ -6,10 +6,10 @@ import { useActionData, useNavigation } from "@remix-run/react";
 import { Form } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import { z } from "zod";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { authenticator } from "~/utils/auth.server";
-import { LocaleLink } from "~/components/LocaleLink";
 import { searchTitle } from "./functions/queries.server";
 
 export const meta: MetaFunction = () => {

--- a/web/app/routes/$locale+/terms/route.tsx
+++ b/web/app/routes/$locale+/terms/route.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@remix-run/react";
+import { LocaleLink } from "~/components/LocaleLink";
 
 export default function TermsPage() {
 	return (
@@ -127,9 +127,9 @@ export default function TermsPage() {
 				</section>
 
 				<div className="mt-8">
-					<Link to="/" className="text-blue-600 hover:underline">
+					<LocaleLink to="/" className="text-blue-600 hover:underline">
 						Return to Home
-					</Link>
+					</LocaleLink>
 				</div>
 			</main>
 		</div>

--- a/web/app/routes/$locale+/user.$userName+/components/PageActionsDropdown.tsx
+++ b/web/app/routes/$locale+/user.$userName+/components/PageActionsDropdown.tsx
@@ -1,5 +1,5 @@
-import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { MoreVertical } from "lucide-react";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Button } from "~/components/ui/button";
 import {
 	DropdownMenu,

--- a/web/app/routes/$locale+/user.$userName+/components/PageActionsDropdown.tsx
+++ b/web/app/routes/$locale+/user.$userName+/components/PageActionsDropdown.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "@remix-run/react";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { MoreVertical } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
@@ -36,7 +36,7 @@ export function PageActionsDropdown({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end">
 				<DropdownMenuItem asChild>
-					<NavLink to={editPath}>Edit</NavLink>
+					<NavLocaleLink to={editPath}>Edit</NavLocaleLink>
 				</DropdownMenuItem>
 				<DropdownMenuItem onSelect={onTogglePublic}>
 					{isPublished ? "Make Private" : "Make Public"}

--- a/web/app/routes/$locale+/user.$userName+/index.tsx
+++ b/web/app/routes/$locale+/user.$userName+/index.tsx
@@ -32,6 +32,7 @@ import {
 	fetchPageById,
 	fetchSanitizedUserWithPages,
 } from "./functions/queries.server";
+import { LocaleLink } from "~/components/LocaleLink";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
 	if (!data) {
@@ -160,11 +161,11 @@ export default function UserPage() {
 							<CardTitle className="text-2xl font-bold flex justify-between items-center">
 								<div>{sanitizedUserWithPages.displayName}</div>
 								{isOwner && (
-									<Link to={`/user/${sanitizedUserWithPages.userName}/edit`}>
+									<LocaleLink to={`/user/${sanitizedUserWithPages.userName}/edit`}>
 										<Button variant="ghost">
 											<Settings className="w-6 h-6" />
 										</Button>
-									</Link>
+									</LocaleLink>
 								)}
 							</CardTitle>
 						</CardHeader>

--- a/web/app/routes/$locale+/user.$userName+/index.tsx
+++ b/web/app/routes/$locale+/user.$userName+/index.tsx
@@ -8,6 +8,7 @@ import { useSearchParams } from "@remix-run/react";
 import Linkify from "linkify-react";
 import { Settings } from "lucide-react";
 import { useState } from "react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { PageCard } from "~/components/PageCard";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
@@ -32,7 +33,6 @@ import {
 	fetchPageById,
 	fetchSanitizedUserWithPages,
 } from "./functions/queries.server";
-import { LocaleLink } from "~/components/LocaleLink";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
 	if (!data) {
@@ -161,7 +161,9 @@ export default function UserPage() {
 							<CardTitle className="text-2xl font-bold flex justify-between items-center">
 								<div>{sanitizedUserWithPages.displayName}</div>
 								{isOwner && (
-									<LocaleLink to={`/user/${sanitizedUserWithPages.userName}/edit`}>
+									<LocaleLink
+										to={`/user/${sanitizedUserWithPages.userName}/edit`}
+									>
 										<Button variant="ghost">
 											<Settings className="w-6 h-6" />
 										</Button>

--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/ContentWithTranslations.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/ContentWithTranslations.tsx
@@ -1,5 +1,5 @@
 import type { UserAITranslationInfo } from "@prisma/client";
-import { Link } from "@remix-run/react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Hash, Loader2 } from "lucide-react";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
@@ -65,8 +65,8 @@ export function ContentWithTranslations({
 			</div>
 
 			<div className="flex items-center not-prose">
-				<Link
-					to={`/${pageWithTranslations.user.userName}`}
+				<LocaleLink
+					to={`/user/${pageWithTranslations.user.userName}`}
 					className="flex items-center mr-2 !no-underline hover:text-gray-700"
 				>
 					<Avatar className="w-12 h-12 flex-shrink-0 mr-3 ">
@@ -86,7 +86,7 @@ export function ContentWithTranslations({
 							{pageWithTranslations.page.createdAt}
 						</span>
 					</div>
-				</Link>
+				</LocaleLink>
 			</div>
 			<TranslateActionSection
 				pageId={pageWithTranslations.page.id}

--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/ContentWithTranslations.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/ContentWithTranslations.tsx
@@ -1,7 +1,7 @@
 import type { UserAITranslationInfo } from "@prisma/client";
-import { LocaleLink } from "~/components/LocaleLink";
 import { Hash, Loader2 } from "lucide-react";
 import { useHydrated } from "remix-utils/use-hydrated";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import type {
 	PageWithTranslations,

--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
@@ -1,7 +1,7 @@
-import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Lock } from "lucide-react";
 import { SquarePen } from "lucide-react";
 import type { ReactNode } from "react";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import type { SourceTextWithTranslations } from "../../types";
 import { TranslationSection } from "./TranslationSection";
 interface SourceTextAndTranslationSectionProps {

--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "@remix-run/react";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Lock } from "lucide-react";
 import { SquarePen } from "lucide-react";
 import type { ReactNode } from "react";
@@ -44,14 +44,14 @@ export function SourceTextAndTranslationSection({
 					</span>
 					{isOwner && slug && (
 						<div className="ml-auto">
-							<NavLink
+							<NavLocaleLink
 								to={`/user/${currentUserName}/page/${slug}/edit`}
 								className={({ isPending }) =>
 									isPending ? "opacity-50" : "opacity-100"
 								}
 							>
 								<SquarePen className="w-5 h-5" />
-							</NavLink>
+							</NavLocaleLink>
 						</div>
 					)}
 				</div>

--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/TranslationSection.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/TranslationSection.tsx
@@ -1,7 +1,7 @@
-import { LocaleLink } from "~/components/LocaleLink";
 import { Languages, Plus } from "lucide-react";
 import { useState } from "react";
 import { useHydrated } from "remix-utils/use-hydrated";
+import { LocaleLink } from "~/components/LocaleLink";
 import { VoteButtons } from "~/routes/resources+/vote-buttons";
 import type { SourceTextWithTranslations } from "../../types";
 import { sanitizeAndParseText } from "../../utils/sanitize-and-parse-text.client";

--- a/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/TranslationSection.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page+/$slug+/components/sourceTextAndTranslationSection/TranslationSection.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@remix-run/react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Languages, Plus } from "lucide-react";
 import { useState } from "react";
 import { useHydrated } from "remix-utils/use-hydrated";
@@ -46,14 +46,14 @@ export function TranslationSection({
 			{isSelected && (
 				<>
 					<div className="flex items-center justify-end">
-						<Link
+						<LocaleLink
 							to={`/user/${bestTranslationWithVote?.user.userName}`}
 							className="!no-underline mr-2"
 						>
 							<p className="text-sm text-gray-500 text-right flex justify-end items-center">
 								by: {bestTranslationWithVote?.user.displayName}
 							</p>
-						</Link>
+						</LocaleLink>
 						<VoteButtons translationWithVote={bestTranslationWithVote} />
 					</div>
 					<AddAndVoteTranslations

--- a/web/app/routes/$locale+/user.$userName+/page-management/components/PageManagementTab.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page-management/components/PageManagementTab.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "@remix-run/react";
 import { useFetcher } from "@remix-run/react";
 import { useEffect, useState } from "react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -24,7 +25,6 @@ import {
 import { DeletePageDialog } from "../../components/DeletePageDialog";
 import { PageActionsDropdown } from "../../components/PageActionsDropdown";
 import type { PageWithTitle } from "../types";
-import { LocaleLink } from "~/components/LocaleLink";
 interface PageManagementTabProps {
 	pagesWithTitle: PageWithTitle[];
 	totalPages: number;
@@ -183,7 +183,9 @@ export function PageManagementTab({
 									/>
 								</TableCell>
 								<TableCell className="font-medium">
-									<LocaleLink to={`/user/${userName}/page/${pageWithTitle.slug}`}>
+									<LocaleLink
+										to={`/user/${userName}/page/${pageWithTitle.slug}`}
+									>
 										{pageWithTitle.title}
 									</LocaleLink>
 								</TableCell>

--- a/web/app/routes/$locale+/user.$userName+/page-management/components/PageManagementTab.tsx
+++ b/web/app/routes/$locale+/user.$userName+/page-management/components/PageManagementTab.tsx
@@ -1,6 +1,5 @@
 import { useSearchParams } from "@remix-run/react";
 import { useFetcher } from "@remix-run/react";
-import { Link } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -25,6 +24,7 @@ import {
 import { DeletePageDialog } from "../../components/DeletePageDialog";
 import { PageActionsDropdown } from "../../components/PageActionsDropdown";
 import type { PageWithTitle } from "../types";
+import { LocaleLink } from "~/components/LocaleLink";
 interface PageManagementTabProps {
 	pagesWithTitle: PageWithTitle[];
 	totalPages: number;
@@ -183,9 +183,9 @@ export function PageManagementTab({
 									/>
 								</TableCell>
 								<TableCell className="font-medium">
-									<Link to={`/user/${userName}/page/${pageWithTitle.slug}`}>
+									<LocaleLink to={`/user/${userName}/page/${pageWithTitle.slug}`}>
 										{pageWithTitle.title}
-									</Link>
+									</LocaleLink>
 								</TableCell>
 								<TableCell>
 									{getStatusBadge(pageWithTitle.isPublished)}

--- a/web/app/routes/resources+/footer.tsx
+++ b/web/app/routes/resources+/footer.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@remix-run/react";
+import { LocaleLink } from "~/components/LocaleLink";
 import { FaDiscord, FaGithub } from "react-icons/fa";
 
 export function Footer() {
@@ -6,18 +6,18 @@ export function Footer() {
 		<footer className="mt-auto">
 			<div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
 				<div className="flex justify-center items-center text-sm text-gray-600 dark:text-gray-300 gap-4">
-					<Link
+					<LocaleLink
 						to="/privacy"
 						className="hover:text-gray-900 dark:hover:text-white"
 					>
 						Privacy Policy
-					</Link>
-					<Link
+					</LocaleLink>
+					<LocaleLink
 						to="/terms"
 						className="hover:text-gray-900 dark:hover:text-white"
 					>
 						Terms of Service
-					</Link>
+					</LocaleLink>
 					<a
 						href="https://github.com/ttizze/eveeve"
 						target="_blank"

--- a/web/app/routes/resources+/footer.tsx
+++ b/web/app/routes/resources+/footer.tsx
@@ -1,5 +1,5 @@
-import { LocaleLink } from "~/components/LocaleLink";
 import { FaDiscord, FaGithub } from "react-icons/fa";
+import { LocaleLink } from "~/components/LocaleLink";
 
 export function Footer() {
 	return (

--- a/web/app/routes/resources+/header.tsx
+++ b/web/app/routes/resources+/header.tsx
@@ -1,9 +1,9 @@
 import { data } from "@remix-run/node";
 import type { ActionFunctionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
-import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Search } from "lucide-react";
 import { BaseHeaderLayout } from "~/components/BaseHeaderLayout";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { StartButton } from "~/components/StartButton";
 import type { SanitizedUser } from "~/types";
 import { authenticator } from "~/utils/auth.server";

--- a/web/app/routes/resources+/header.tsx
+++ b/web/app/routes/resources+/header.tsx
@@ -1,7 +1,7 @@
 import { data } from "@remix-run/node";
 import type { ActionFunctionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
-import { NavLink } from "@remix-run/react";
+import { NavLocaleLink } from "~/components/NavLocaleLink";
 import { Search } from "lucide-react";
 import { BaseHeaderLayout } from "~/components/BaseHeaderLayout";
 import { StartButton } from "~/components/StartButton";
@@ -37,7 +37,7 @@ export async function action({ request }: ActionFunctionArgs) {
 export function Header({ currentUser }: HeaderProps) {
 	const rightExtra = (
 		<>
-			<NavLink
+			<NavLocaleLink
 				to="/search"
 				className={({ isPending }) =>
 					isPending
@@ -46,7 +46,7 @@ export function Header({ currentUser }: HeaderProps) {
 				}
 			>
 				<Search className="w-6 h-6 " />
-			</NavLink>
+			</NavLocaleLink>
 			{currentUser ? (
 				<NewPageButton userName={currentUser.userName} />
 			) : (

--- a/web/app/routes/resources+/translation-list-item.tsx
+++ b/web/app/routes/resources+/translation-list-item.tsx
@@ -1,6 +1,5 @@
 import { data } from "@remix-run/node";
 import type { ActionFunctionArgs } from "@remix-run/node";
-import { Link } from "@remix-run/react";
 import { useFetcher } from "@remix-run/react";
 import { EllipsisVertical } from "lucide-react";
 import { z } from "zod";
@@ -16,6 +15,7 @@ import { sanitizeAndParseText } from "~/routes/$locale+/user.$userName+/page+/$s
 import { authenticator } from "~/utils/auth.server";
 import { deleteOwnTranslation } from "./functions/mutations.server";
 import { VoteButtons } from "./vote-buttons";
+import { LocaleLink } from "~/components/LocaleLink";
 
 const schema = z.object({
 	translationId: z.number(),
@@ -80,14 +80,14 @@ export function TranslationListItem({
 				)}
 			</div>
 			<div className="flex items-center justify-end">
-				<Link
+				<LocaleLink
 					to={`/user/${translation.user.userName}`}
 					className="!no-underline mr-2"
 				>
 					<p className="text-sm text-gray-500 text-right flex justify-end items-center  ">
 						by: {translation.user.displayName}
 					</p>
-				</Link>
+				</LocaleLink>
 				<VoteButtons translationWithVote={translation} />
 			</div>
 		</div>

--- a/web/app/routes/resources+/translation-list-item.tsx
+++ b/web/app/routes/resources+/translation-list-item.tsx
@@ -3,6 +3,7 @@ import type { ActionFunctionArgs } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import { EllipsisVertical } from "lucide-react";
 import { z } from "zod";
+import { LocaleLink } from "~/components/LocaleLink";
 import { Button } from "~/components/ui/button";
 import {
 	DropdownMenu,
@@ -15,7 +16,6 @@ import { sanitizeAndParseText } from "~/routes/$locale+/user.$userName+/page+/$s
 import { authenticator } from "~/utils/auth.server";
 import { deleteOwnTranslation } from "./functions/mutations.server";
 import { VoteButtons } from "./vote-buttons";
-import { LocaleLink } from "~/components/LocaleLink";
 
 const schema = z.object({
 	translationId: z.number(),


### PR DESCRIPTION
This pull request updates the application to use `LocaleLink` instead of the standard `Link` component from Remix. This change is made across various pages to ensure that links are properly localized based on the user's locale. Additionally, a new `NavLocaleLink` component is introduced to handle navigation links with locale support. This enhances the user experience by providing localized routing throughout the application.