### PR TITLE
Replace useMatches with useParams in LocaleLink and NavLocaleLink components

### DIFF
--- a/web/app/components/LocaleLink.tsx
+++ b/web/app/components/LocaleLink.tsx
@@ -1,11 +1,6 @@
 // LocaleLink.tsx
-import { Link, useMatches } from "@remix-run/react";
+import { Link, useParams } from "@remix-run/react";
 
-function useRootData() {
-	const matches = useMatches();
-	const rootMatch = matches.find((match) => match.id === "root");
-	return rootMatch?.data as { locale: string } | undefined;
-}
 
 export function LocaleLink({
 	to,
@@ -16,8 +11,7 @@ export function LocaleLink({
 	children: React.ReactNode;
 	className?: string;
 }) {
-	const rootData = useRootData();
-	const locale = rootData?.locale ?? "en";
+  const { locale } = useParams();
 
 	const path = `/${locale}${to}`;
 

--- a/web/app/components/LocaleLink.tsx
+++ b/web/app/components/LocaleLink.tsx
@@ -1,7 +1,6 @@
 // LocaleLink.tsx
 import { Link, useParams } from "@remix-run/react";
 
-
 export function LocaleLink({
 	to,
 	children,
@@ -11,7 +10,7 @@ export function LocaleLink({
 	children: React.ReactNode;
 	className?: string;
 }) {
-  const { locale } = useParams();
+	const { locale } = useParams();
 
 	const path = `/${locale}${to}`;
 

--- a/web/app/components/NavLocaleLink.tsx
+++ b/web/app/components/NavLocaleLink.tsx
@@ -1,6 +1,5 @@
 import { NavLink, type NavLinkProps, useParams } from "@remix-run/react";
 
-
 // NavLinkProps を継承
 type NavLocaleLinkProps = Omit<NavLinkProps, "to"> & {
 	to: string;
@@ -12,17 +11,13 @@ export function NavLocaleLink({
 	children,
 	...rest
 }: NavLocaleLinkProps) {
-  const { locale } = useParams();
+	const { locale } = useParams();
 
 	const normalized = to.startsWith("/") ? to.slice(1) : to;
 	const path = `/${locale}/${normalized}`;
 
 	return (
-		<NavLink
-			to={path}
-			className={className}
-			{...rest}
-		>
+		<NavLink to={path} className={className} {...rest}>
 			{children}
 		</NavLink>
 	);

--- a/web/app/components/NavLocaleLink.tsx
+++ b/web/app/components/NavLocaleLink.tsx
@@ -1,10 +1,5 @@
-import { NavLink, type NavLinkProps, useMatches } from "@remix-run/react";
+import { NavLink, type NavLinkProps, useParams } from "@remix-run/react";
 
-function useRootData() {
-	const matches = useMatches();
-	const rootMatch = matches.find((match) => match.id === "root");
-	return rootMatch?.data as { locale?: string } | undefined;
-}
 
 // NavLinkProps を継承
 type NavLocaleLinkProps = Omit<NavLinkProps, "to"> & {
@@ -17,17 +12,14 @@ export function NavLocaleLink({
 	children,
 	...rest
 }: NavLocaleLinkProps) {
-	const rootData = useRootData();
-	const locale = rootData?.locale ?? "en";
+  const { locale } = useParams();
 
-	// 先頭のスラッシュを削除したうえで "/:locale" を付与
 	const normalized = to.startsWith("/") ? to.slice(1) : to;
 	const path = `/${locale}/${normalized}`;
 
 	return (
 		<NavLink
 			to={path}
-			// className が「文字列」or「コールバック」どちらでもOK
 			className={className}
 			{...rest}
 		>


### PR DESCRIPTION
This PR simplifies the data retrieval process in the LocaleLink and NavLocaleLink components by replacing the use of `useMatches` with `useParams`. This change streamlines how locale information is accessed, enhancing the overall efficiency of the components.