### PR TITLE
Cleanup test processes and manage loading state in NewPageButton component

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,3 +12,4 @@ node_modules
 
 # Sentry Config File
 .env.sentry-build-plugin
+temp-repo

--- a/web/app/features/translate/lib/translate.server.test.ts
+++ b/web/app/features/translate/lib/translate.server.test.ts
@@ -3,7 +3,7 @@
 // Gemini側が途中で失敗した場合（空レスポンス等で翻訳ができない）のテストケースを追加している。
 // Prismaは実際にはテスト用DB等が必要だが、この例ではあくまで構成例である。
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "~/utils/prisma";
 import { translate } from "../lib/translate.server"; // テスト対象となるtranslate関数
 import { getGeminiModelResponse } from "../services/gemini";
@@ -55,7 +55,6 @@ describe("translate関数テスト (geminiのみモック)", () => {
 		});
 		userAITranslationInfoId = userAITranslationInfo.id;
 	});
-
 
 	test("正常ケース：Geminiモックレスポンスを与えて結果が成功するか", async () => {
 		const params: TranslateJobParams = {

--- a/web/app/features/translate/lib/translate.server.test.ts
+++ b/web/app/features/translate/lib/translate.server.test.ts
@@ -56,13 +56,6 @@ describe("translate関数テスト (geminiのみモック)", () => {
 		userAITranslationInfoId = userAITranslationInfo.id;
 	});
 
-	afterEach(async () => {
-		// テスト後のクリーンアップ（必要に応じて）
-		await prisma.translateText.deleteMany();
-		await prisma.userAITranslationInfo.deleteMany();
-		await prisma.page.deleteMany();
-		await prisma.user.deleteMany();
-	});
 
 	test("正常ケース：Geminiモックレスポンスを与えて結果が成功するか", async () => {
 		const params: TranslateJobParams = {

--- a/web/app/routes/resources+/components/NewPageButton.tsx
+++ b/web/app/routes/resources+/components/NewPageButton.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@remix-run/react";
 import { Loader2, PencilIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const generateSlug = (length = 8): string => {
 	const charset =
@@ -21,6 +21,11 @@ interface NewPageButtonProps {
 export const NewPageButton = ({ userName }: NewPageButtonProps) => {
 	const navigate = useNavigate();
 	const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
+
 	const handleNewPage = () => {
 		setIsLoading(true);
 		const newSlug = generateSlug();

--- a/web/app/routes/resources+/components/NewPageButton.tsx
+++ b/web/app/routes/resources+/components/NewPageButton.tsx
@@ -22,9 +22,9 @@ export const NewPageButton = ({ userName }: NewPageButtonProps) => {
 	const navigate = useNavigate();
 	const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
+	useEffect(() => {
+		setIsLoading(false);
+	}, []);
 
 	const handleNewPage = () => {
 		setIsLoading(true);


### PR DESCRIPTION
This pull request removes the cleanup process from the tests and adds a `useEffect` hook to the `NewPageButton` component to manage its loading state. This change enhances the component's functionality by ensuring that the loading state is properly handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new entry to the `.gitignore` to ignore the `temp-repo` directory.
	- Enhanced test coverage for the `translate` function to handle failure scenarios.

- **Bug Fixes**
	- Adjusted the `NewPageButton` component to reset the loading state on mount.

- **Tests**
	- Removed cleanup function in unit tests, allowing database state to persist across tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->