### PR TITLE
Update install-and-build script in package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "remix vite:build",
-		"install-and-build": "rm -rf node_modules && npm install && npm run build",
+		"install-and-build": "npm ci --production=false && npm run build && npm prune --production",
 		"dev": "remix vite:dev --host 0.0.0.0",
 		"start": "NODE_OPTIONS='--import ./instrumentation.server.mjs' remix-serve ./build/server/index.js",
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
This PR modifies the `install-and-build` script in `package.json` to use `npm ci` for a cleaner installation process, followed by building the project and pruning unnecessary production dependencies. This change enhances the efficiency and reliability of the build process.