### PR TITLE
Update build command in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -11,7 +11,7 @@ services:
   branch: main
   plan: starter
   region: singapore
-  buildCommand: pnpm install && pnpm run build
+  buildCommand: npm ci --production=false && npm run build && npm prune --production
   startCommand: npx prisma migrate deploy && npx prisma generate && pnpm start
   rootDir: web
   envVars:


### PR DESCRIPTION
This PR modifies the build command in `render.yaml` to use `npm ci` for installation, allowing for a non-production build, followed by a prune step to remove unnecessary packages. This change aims to streamline the build process and improve efficiency.