### PR TITLE
TOCコンポーネントの初期化処理を改善し、コンテンツが完全にレンダリングされた後に実行されるようにしました。また、見出しラベルの切り詰めを20文字に変更し、TOCの状態管理を改善しました。さらに、TOCコンポーネントのテストを追加しました。

### DIFF
--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/content-with-translations.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/content-with-translations.tsx
@@ -5,13 +5,13 @@ import {
 } from "@/app/[locale]/(common-layout)/user/[handle]/page/[slug]/constants";
 import { TagList } from "@/app/[locale]/components/tag-list";
 import type { PageWithTranslations } from "@/app/[locale]/types";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Link } from "@/i18n/routing";
 import type {
 	PageAITranslationInfo,
 	UserAITranslationInfo,
 } from "@prisma/client";
+
 import dynamic from "next/dynamic";
+import { SubHeader } from "./sub-header";
 const DynamicTranslateActionSection = dynamic(
 	() =>
 		import("@/app/[locale]/components/translate-action-section").then(
@@ -77,29 +77,7 @@ export async function ContentWithTranslations({
 			<TagList
 				tag={pageWithTranslations.tagPages.map((tagPage) => tagPage.tag)}
 			/>
-
-			<div className="flex items-center not-prose">
-				<Link
-					href={`/user/${pageWithTranslations.user.handle}`}
-					className="flex items-center mr-2 !no-underline hover:text-gray-700"
-				>
-					<Avatar className="w-10 h-10 flex-shrink-0 mr-3 ">
-						<AvatarImage
-							src={pageWithTranslations.user.image}
-							alt={pageWithTranslations.user.name}
-						/>
-						<AvatarFallback>
-							{pageWithTranslations.user.name.charAt(0).toUpperCase()}
-						</AvatarFallback>
-					</Avatar>
-					<div className="flex flex-col">
-						<span className="text-sm">{pageWithTranslations.user.name}</span>
-						<span className="text-xs text-gray-500">
-							{pageWithTranslations.page.createdAt}
-						</span>
-					</div>
-				</Link>
-			</div>
+			<SubHeader pageWithTranslations={pageWithTranslations} />
 			<DynamicTranslateActionSection
 				pageId={pageWithTranslations.page.id}
 				currentHandle={currentHandle}

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/floating-controls.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/floating-controls.tsx
@@ -2,12 +2,10 @@
 import { LikeButton } from "@/app/[locale]/components/like-button/client";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Languages, List, Text } from "lucide-react"; // List アイコンをインポート
+import { Languages, Text } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ShareDialog } from "./share-dialog";
-import Toc from "./toc";
-
 interface FloatingControlsProps {
 	liked: boolean;
 	likeCount: number;
@@ -25,7 +23,6 @@ export function FloatingControls({
 }: FloatingControlsProps) {
 	const [isVisible, setIsVisible] = useState(true);
 	const [lastScrollY, setLastScrollY] = useState(0);
-	const [isTocOpen, setIsTocOpen] = useState(false);
 	const ignoreScrollRef = useRef(false);
 
 	const [showOriginal, setShowOriginal] = useQueryState("showOriginal", {
@@ -77,7 +74,6 @@ export function FloatingControls({
 		} else {
 			// 上方向へのスクロール - コントロールを表示
 			setIsVisible(true);
-			setIsTocOpen(false);
 		}
 
 		// ページ最上部付近（ビューポートの3%以内）では常に表示
@@ -87,20 +83,6 @@ export function FloatingControls({
 
 		setLastScrollY(currentScrollY);
 	}, [lastScrollY]);
-
-	const handleTocItemClick = useCallback(() => {
-		// 一時的にスクロールイベントを無視して、
-		// スクロールによる表示/非表示の切り替えが起きないようにする
-		ignoreScrollRef.current = true;
-
-		// コントロールを非表示にする
-		setIsVisible(false);
-		setIsTocOpen(false);
-		// 少し遅延してからスクロールイベントの監視を再開
-		setTimeout(() => {
-			ignoreScrollRef.current = false;
-		}, 500); // ユーザーがスクロール位置に到達するのに十分な時間
-	}, []);
 
 	useEffect(() => {
 		window.addEventListener("scroll", handleShowFloatingControls, {
@@ -170,27 +152,6 @@ export function FloatingControls({
 			</div>
 		);
 	};
-	const renderToc = () => {
-		if (!isTocOpen) {
-			return (
-				<Button
-					variant="ghost"
-					size="icon"
-					className={`${STYLE.baseClasses} border relative bg-background self-end`}
-					onClick={() => setIsTocOpen(true)}
-					title="Table of Contents"
-				>
-					<List className="h-5 w-5" />
-				</Button>
-			);
-		}
-
-		return (
-			<div className={STYLE.tocContainerClasses}>
-				<Toc onItemClick={handleTocItemClick} />
-			</div>
-		);
-	};
 
 	return (
 		<div
@@ -199,13 +160,7 @@ export function FloatingControls({
 				isVisible ? "translate-y-0 opacity-100" : "translate-y-20 opacity-0",
 			)}
 		>
-			<div className="flex flex-col gap-3">
-				<div className="flex justify-end">
-					{/* 右端に目次ボタンを配置 */}
-					{renderToc()}
-				</div>
-				{renderControlButtons()}
-			</div>
+			{renderControlButtons()}
 		</div>
 	);
 }

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/sub-header.test.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/sub-header.test.tsx
@@ -1,0 +1,172 @@
+import type { PageWithTranslations } from "@/app/[locale]/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+import { SubHeader } from "./sub-header";
+import * as TocModule from "./toc";
+
+// Mock the dependencies
+vi.mock("@/i18n/routing", () => ({
+	Link: ({
+		children,
+		...props
+	}: { children: ReactNode; href: string; className?: string }) => (
+		<a {...props}>{children}</a>
+	),
+}));
+
+interface HeadroomProps {
+	children: ReactNode;
+	onPin: () => void;
+	onUnpin: () => void;
+	onUnfix: () => void;
+}
+
+vi.mock("react-headroom", () => ({
+	default: ({ children, onPin, onUnpin, onUnfix }: HeadroomProps) => (
+		<div
+			data-testid="headroom"
+			onClick={() => {
+				onPin();
+				onUnpin();
+				onUnfix();
+			}}
+			onKeyUp={() => {
+				onPin();
+				onUnpin();
+				onUnfix();
+			}}
+			onKeyDown={() => {
+				onPin();
+				onUnpin();
+				onUnfix();
+			}}
+		>
+			{children}
+		</div>
+	),
+}));
+
+interface TocProps {
+	onItemClick: () => void;
+}
+
+vi.mock("./toc", () => ({
+	__esModule: true,
+	default: ({ onItemClick }: TocProps) => (
+		<div
+			data-testid="toc"
+			onClick={onItemClick}
+			onKeyUp={onItemClick}
+			onKeyDown={onItemClick}
+			onKeyPress={onItemClick}
+		>
+			Table of Contents
+		</div>
+	),
+	useHasTableOfContents: vi.fn(),
+}));
+
+describe("SubHeader", () => {
+	const mockPageWithTranslations = {
+		user: {
+			handle: "testuser",
+			name: "Test User",
+			image: "/test-image.jpg",
+		},
+		page: {
+			createdAt: "2023-01-01",
+			slug: "test-page",
+			title: "Test Page",
+			content: "Test content",
+			translations: [],
+		},
+	} as unknown as PageWithTranslations;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("renders user information correctly", () => {
+		vi.mocked(TocModule.useHasTableOfContents).mockReturnValue(false);
+
+		render(<SubHeader pageWithTranslations={mockPageWithTranslations} />);
+
+		expect(screen.getByText("Test User")).toBeInTheDocument();
+		expect(screen.getByText("2023-01-01")).toBeInTheDocument();
+	});
+
+	test("does not render TOC button when no TOC content", () => {
+		vi.mocked(TocModule.useHasTableOfContents).mockReturnValue(false);
+
+		render(<SubHeader pageWithTranslations={mockPageWithTranslations} />);
+
+		expect(screen.queryByTitle("Table of Contents")).not.toBeInTheDocument();
+	});
+
+	test("renders TOC button when TOC content exists", () => {
+		vi.mocked(TocModule.useHasTableOfContents).mockReturnValue(true);
+
+		render(<SubHeader pageWithTranslations={mockPageWithTranslations} />);
+
+		expect(screen.getByTitle("Table of Contents")).toBeInTheDocument();
+	});
+
+	test("toggles TOC visibility when TOC button is clicked", () => {
+		vi.mocked(TocModule.useHasTableOfContents).mockReturnValue(true);
+
+		render(<SubHeader pageWithTranslations={mockPageWithTranslations} />);
+
+		// TOC should not be visible initially
+		expect(screen.queryByTestId("toc")).not.toBeInTheDocument();
+
+		// Click the TOC button
+		fireEvent.click(screen.getByTitle("Table of Contents"));
+
+		// TOC should now be visible
+		expect(screen.getByTestId("toc")).toBeInTheDocument();
+
+		// Click the TOC button again
+		fireEvent.click(screen.getByTitle("Table of Contents"));
+
+		// TOC should be hidden again
+		expect(screen.queryByTestId("toc")).not.toBeInTheDocument();
+	});
+
+	test("closes TOC when a TOC item is clicked", () => {
+		vi.mocked(TocModule.useHasTableOfContents).mockReturnValue(true);
+
+		render(<SubHeader pageWithTranslations={mockPageWithTranslations} />);
+
+		// Open the TOC
+		fireEvent.click(screen.getByTitle("Table of Contents"));
+		expect(screen.getByTestId("toc")).toBeInTheDocument();
+
+		// Click a TOC item
+		fireEvent.click(screen.getByTestId("toc"));
+
+		// TOC should be hidden
+		expect(screen.queryByTestId("toc")).not.toBeInTheDocument();
+	});
+
+	test("updates isPinned state when Headroom events are triggered", () => {
+		vi.mocked(TocModule.useHasTableOfContents).mockReturnValue(false);
+
+		render(<SubHeader pageWithTranslations={mockPageWithTranslations} />);
+
+		const headroom = screen.getByTestId("headroom");
+
+		// Initially, the component should not have the px-4 class
+		const container = screen
+			.getByText("Test User")
+			.closest(".flex.items-center");
+		expect(container).not.toHaveClass("px-4");
+
+		// Trigger Headroom events
+		fireEvent.click(headroom);
+
+		// The class should be applied and then removed due to the sequence of events in our mock
+		// This is a simplified test since we can't easily test the actual pinning behavior
+		expect(container).not.toHaveClass("px-4");
+	});
+});

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/sub-header.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/sub-header.tsx
@@ -1,0 +1,93 @@
+"use client";
+import type { PageWithTranslations } from "@/app/[locale]/types";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/routing";
+import { ChevronDown, List } from "lucide-react";
+import { useState } from "react";
+import Headroom from "react-headroom";
+import Toc, { useHasTableOfContents } from "./toc";
+
+export function SubHeader({
+	pageWithTranslations,
+}: {
+	pageWithTranslations: PageWithTranslations;
+}) {
+	const [isTocOpen, setIsTocOpen] = useState(false);
+	const [isPinned, setIsPinned] = useState(false);
+	const hasTocContent = useHasTableOfContents();
+
+	const renderToc = () => {
+		if (!hasTocContent) return null;
+
+		return (
+			<>
+				<Button
+					variant="ghost"
+					className={
+						"relative bg-background self-end flex items-center gap-1 rounded-full"
+					}
+					onClick={() => setIsTocOpen(!isTocOpen)}
+					title="Table of Contents"
+				>
+					<List className="h-5 w-5" />
+					<div
+						className="transition-transform duration-300 ease-in-out"
+						style={{ transform: isTocOpen ? "rotate(180deg)" : "rotate(0deg)" }}
+					>
+						<ChevronDown className="h-4 w-4" />
+					</div>
+				</Button>
+
+				{isTocOpen && (
+					<div
+						className={`absolute right-0 top-full mt-2 z-50 bg-background rounded-xl
+          px-3 py-4 drop-shadow-xl dark:drop-shadow-[0_9px_7px_rgba(255,255,255,0.1)] 
+          border border-border animate-in zoom-in-95 duration-200`}
+					>
+						<Toc onItemClick={() => setIsTocOpen(false)} />
+					</div>
+				)}
+			</>
+		);
+	};
+
+	return (
+		<Headroom
+			onPin={() => setIsPinned(true)}
+			onUnpin={() => setIsPinned(false)}
+			onUnfix={() => setIsPinned(false)}
+		>
+			<div className="bg-background py-4">
+				<div
+					className={`w-full prose dark:prose-invert sm:prose lg:prose-lg mx-auto 
+          flex items-center not-prose justify-between relative ${isPinned ? "px-4" : ""}`}
+				>
+					<Link
+						href={`/user/${pageWithTranslations.user.handle}`}
+						className="flex items-center mr-2 !no-underline hover:text-gray-700"
+					>
+						<Avatar className="w-10 h-10 flex-shrink-0 mr-3 ">
+							<AvatarImage
+								src={pageWithTranslations.user.image}
+								alt={pageWithTranslations.user.name}
+							/>
+							<AvatarFallback>
+								{pageWithTranslations.user.name.charAt(0).toUpperCase()}
+							</AvatarFallback>
+						</Avatar>
+						<div className="flex flex-col">
+							<span className="text-sm">{pageWithTranslations.user.name}</span>
+							{!isPinned && (
+								<span className="text-xs text-gray-500">
+									{pageWithTranslations.page.createdAt}
+								</span>
+							)}
+						</div>
+					</Link>
+					{renderToc()}
+				</div>
+			</div>
+		</Headroom>
+	);
+}

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/toc.test.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/toc.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render } from "@testing-library/react";
+import * as tocbot from "tocbot";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TableOfContents from "./toc";
+
+// tocbotのモック
+vi.mock("tocbot", () => ({
+	init: vi.fn(),
+	destroy: vi.fn(),
+}));
+
+describe("TableOfContents", () => {
+	const mockOnItemClick = vi.fn();
+
+	beforeEach(() => {
+		// DOMに必要な要素を追加
+		document.body.innerHTML = `
+      <div class="js-content">
+        <h1 id="heading1">Heading 1</h1>
+        <h2 id="heading2">Heading 2</h2>
+        <h3 id="heading3">Heading 3</h3>
+      </div>
+    `;
+
+		// タイマーのモック
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.resetAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("should render the TOC container", () => {
+		render(<TableOfContents onItemClick={mockOnItemClick} />);
+		const tocElement = document.querySelector(".js-toc");
+		expect(tocElement).toBeTruthy();
+	});
+
+	it("should call onItemClick when TOC item is clicked", async () => {
+		render(<TableOfContents onItemClick={mockOnItemClick} />);
+
+		vi.advanceTimersByTime(300);
+
+		// tocbot.initが呼ばれた時のonClickコールバックを取得
+		const initCall = vi.mocked(tocbot.init).mock.calls[0][0];
+		const onClickCallback = initCall?.onClick as
+			| ((e: unknown) => void)
+			| undefined;
+
+		// onClickコールバックを手動で呼び出す
+		if (onClickCallback) {
+			onClickCallback({});
+		}
+
+		// onItemClickが呼ばれたことを確認
+		expect(mockOnItemClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("should clean up tocbot on unmount", () => {
+		const { unmount } = render(
+			<TableOfContents onItemClick={mockOnItemClick} />,
+		);
+
+		vi.advanceTimersByTime(300);
+
+		// tocbot.initが呼ばれたことを確認
+		expect(tocbot.init).toHaveBeenCalledTimes(1);
+
+		// コンポーネントをアンマウント
+		unmount();
+
+		// tocbot.destroyが呼ばれたことを確認
+		expect(tocbot.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it("should truncate long heading text", () => {
+		render(<TableOfContents onItemClick={mockOnItemClick} />);
+
+		vi.advanceTimersByTime(300);
+
+		// tocbot.initが呼ばれた時のheadingLabelCallbackを取得
+		const initCall = vi.mocked(tocbot.init).mock.calls[0][0];
+		const headingLabelCallback = initCall?.headingLabelCallback as
+			| ((text: string) => string)
+			| undefined;
+
+		if (headingLabelCallback) {
+			// 短いテキストはそのまま
+			expect(headingLabelCallback("Short text")).toBe("Short text");
+
+			// 長いテキストは切り詰められる
+			const longText =
+				"This is a very long heading text that should be truncated";
+			expect(headingLabelCallback(longText)).toBe("This is a very long ...");
+		} else {
+			throw new Error("headingLabelCallback is undefined");
+		}
+	});
+});

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/toc.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/components/toc.tsx
@@ -1,53 +1,54 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import * as tocbot from "tocbot";
 import "tocbot/dist/tocbot.css";
 
 export default function TableOfContents({
 	onItemClick,
 }: { onItemClick: () => void }) {
-	const tocInitialized = useRef(false);
-
 	useEffect(() => {
-		// Wait for content to be fully rendered
-		const initTocbot = () => {
-			// Check if content exists before initializing
-			if (document.querySelector(".js-content") && !tocInitialized.current) {
-				tocbot.init({
-					tocSelector: ".js-toc",
-					contentSelector: ".js-content",
-					headingSelector: "h1, h2, h3",
-					collapseDepth: 10,
-					orderedList: false,
-					hasInnerContainers: true, // Handle nested containers
-					headingLabelCallback: (text) => {
-						// 20文字以上の場合は20文字に切り詰めて「...」を追加
-						return text.length > 20 ? `${text.substring(0, 20)}...` : text;
-					},
-					onClick: (e) => {
-						// TOCアイテムがクリックされたときにコールバックを呼び出す
-						if (onItemClick) {
-							onItemClick();
-						}
-					},
-					scrollSmoothOffset: -70, // Adjust based on your header height
-				});
-				tocInitialized.current = true;
-			}
-		};
+		if (!document.querySelector(".js-content")) {
+			return;
+		}
 
-		// Try initializing after a short delay to ensure content is rendered
-		const timer = setTimeout(initTocbot, 300);
+		tocbot.init({
+			tocSelector: ".js-toc",
+			contentSelector: ".js-content",
+			headingSelector: "h1, h2, h3",
+			collapseDepth: 10,
+			orderedList: false,
+			hasInnerContainers: true,
+			headingLabelCallback: (text) => {
+				return text.length > 20 ? `${text.substring(0, 20)}...` : text;
+			},
+			onClick: (e) => {
+				if (onItemClick) {
+					onItemClick();
+				}
+			},
+			scrollSmoothOffset: -70,
+		});
 
-		// コンポーネントのアンマウント時にリソースを解放
+		// Clean up on unmount
 		return () => {
-			clearTimeout(timer);
-			if (tocInitialized.current) {
-				tocbot.destroy();
-				tocInitialized.current = false;
-			}
+			tocbot.destroy();
 		};
 	}, [onItemClick]);
 
 	return <nav className="js-toc" />;
+}
+export function useHasTableOfContents(): boolean {
+	const [hasHeadings, setHasHeadings] = useState(false);
+
+	useEffect(() => {
+		const contentElement = document.querySelector(".js-content");
+		if (!contentElement) {
+			return;
+		}
+
+		const headings = contentElement.querySelectorAll("h1, h2, h3");
+		setHasHeadings(headings.length > 0);
+	}, []);
+
+	return hasHeadings;
 }

--- a/next/src/lib/prisma.ts
+++ b/next/src/lib/prisma.ts
@@ -12,7 +12,7 @@ if (!connectionString) {
 	throw new Error("DATABASE_URL is not defined");
 }
 
-if (process.env.NODE_ENV !== "test") {
+if (process.env.NODE_ENV !== "test" && process.env.NODE_ENV !== "development") {
 	neonConfig.webSocketConstructor = WebSocket;
 	neonConfig.poolQueryViaFetch = true;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated sub-header that now displays user details and, when applicable, a toggleable Table of Contents.
  
- **Refactor**
  - Consolidated user display by replacing the inline component with the sub-header.
  - Removed the standalone Table of Contents control for a more streamlined interface.
  
- **Tests**
  - Added tests covering the sub-header presentation and Table of Contents interactions for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->