### PR TITLE
ヒーローセクションの画像クラスにダークモード用のスタイルを追加しました。

### DIFF
--- a/next/src/app/[locale]/_components/hero-section/server.tsx
+++ b/next/src/app/[locale]/_components/hero-section/server.tsx
@@ -91,7 +91,7 @@ export default async function HeroSection({ locale }: { locale: string }) {
 								alt="Hero section image"
 								width={14}
 								height={14}
-								className="relative z-10 invert"
+								className="relative z-10 invert dark:invert-0"
 							/>
 						}
 						className="w-60 h-12 text-xl rounded-full transition-all duration-300 hover:scale-105"


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Added dark mode support for the hero section image by modifying the inversion class to properly display in both light and dark themes.

- Modified the `className` of the favicon image in the hero section's start button to include `dark:invert-0`, ensuring the image displays correctly in dark mode.
- The change ensures visual consistency by inverting the image in light mode but displaying it normally in dark mode.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->