### PR TITLE
Add edit button to SubHeader and interactive properties

### DIFF
--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/content-with-translations.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/content-with-translations.tsx
@@ -60,14 +60,15 @@ export async function ContentWithTranslations({
 				{pageSegmentTitleWithTranslations && (
 					<DynamicSegmentAndTranslationSection
 						segmentBundle={pageSegmentTitleWithTranslations}
-						showLockIcon={pageDetail.status === "DRAFT"}
 						currentHandle={currentUser?.handle}
-						editablePageSlug={editablePageSlug}
 					/>
 				)}
 			</h1>
 			<PageTagList tag={pageDetail.tagPages.map((tagPage) => tagPage.tag)} />
-			<SubHeader pageDetail={pageDetail} />
+			<SubHeader
+				pageDetail={pageDetail}
+				currentUserHandle={currentUser?.handle}
+			/>
 			<DynamicTranslateActionSection
 				pageId={pageDetail.id}
 				currentHandle={currentUser?.handle}

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/content-with-translations.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/content-with-translations.tsx
@@ -49,10 +49,6 @@ export async function ContentWithTranslations({
 	const pageSegmentTitleWithTranslations = pageDetail.segmentBundles.filter(
 		(item) => item.segment.number === 0,
 	)[0];
-	const editablePageSlug =
-		pageDetail.user.handle === currentUser?.handle
-			? pageDetail.slug
-			: undefined;
 
 	return (
 		<>

--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/sub-header.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/sub-header.tsx
@@ -5,18 +5,21 @@ import type { PageDetail } from "@/app/[locale]/types";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/routing";
-import { ChevronDown, List } from "lucide-react";
+import { ChevronDown, List, PencilIcon } from "lucide-react";
 import { getImageProps } from "next/image";
 import { useState } from "react";
 import Toc, { useHasTableOfContents } from "./toc";
 
 export function SubHeader({
 	pageDetail,
+	currentUserHandle,
 }: {
 	pageDetail: PageDetail;
+	currentUserHandle?: string;
 }) {
 	const [isTocOpen, setIsTocOpen] = useState(false);
 	const hasTocContent = useHasTableOfContents();
+	const isEditable = currentUserHandle === pageDetail.user.handle;
 
 	// カスタムフックを使用 - SubHeaderの特殊な動作のため初期オフセットを考慮
 	const { headerRef, isPinned, isVisible, headerHeight } = useHeaderScroll();
@@ -91,7 +94,18 @@ export function SubHeader({
 							)}
 						</div>
 					</Link>
-					{renderToc()}
+					<div className="flex items-center gap-2">
+						{isEditable && (
+							<Link
+								href={`/user/${currentUserHandle}/page/${pageDetail.slug}/edit`}
+							>
+								<Button variant="ghost">
+									<PencilIcon className="h-4 w-4" />
+								</Button>
+							</Link>
+						)}
+						{renderToc()}
+					</div>
 				</div>
 			</div>
 			{isPinned && <div style={{ height: `${headerHeight}px` }} />}

--- a/next/src/app/[locale]/_components/page/page-list.server.tsx
+++ b/next/src/app/[locale]/_components/page/page-list.server.tsx
@@ -84,6 +84,7 @@ export function PageList({
 								segmentBundle={titleSegment}
 								currentHandle={currentUserHandle}
 								segmentTextClassName="line-clamp-1 break-all overflow-wrap-anywhere"
+								interactive={false}
 							/>
 						)}
 					</Link>

--- a/next/src/app/[locale]/_components/project/project-list.server.tsx
+++ b/next/src/app/[locale]/_components/project/project-list.server.tsx
@@ -97,6 +97,7 @@ export async function ProjectList({
 						segmentBundle={tagLineSegment}
 						currentHandle={currentUserHandle}
 						segmentTextClassName="text-sm line-clamp-1 break-all overflow-wrap-anywhere"
+						interactive={false}
 					/>
 				)}
 

--- a/next/src/app/[locale]/_components/segment-and-translation-section/client.tsx
+++ b/next/src/app/[locale]/_components/segment-and-translation-section/client.tsx
@@ -1,25 +1,18 @@
 "use client";
 import type { SegmentBundle } from "@/app/[locale]/types";
 import { useDisplay } from "@/app/_context/display-provider";
-import { Link } from "@/i18n/routing";
-import { Lock } from "lucide-react";
-import { SquarePen } from "lucide-react";
 import { TranslationSection } from "./translation-section";
 
 interface SegmentAndTranslationSectionProps {
 	segmentBundle: SegmentBundle;
-	showLockIcon?: boolean;
 	segmentTextClassName?: string;
 	currentHandle?: string;
-	editablePageSlug?: string;
 }
 
 export function SegmentAndTranslationSection({
 	segmentBundle,
-	showLockIcon = false,
 	segmentTextClassName,
 	currentHandle,
-	editablePageSlug,
 }: SegmentAndTranslationSectionProps) {
 	const { mode } = useDisplay();
 	return (
@@ -33,16 +26,6 @@ export function SegmentAndTranslationSection({
 							: "text-gray-300 dark:text-gray-600 [&>a]:text-gray-300 dark:[&>a]:text-gray-600 [&>strong]:text-gray-300 dark:[&>strong]:text-gray-600"
 					} ${segmentTextClassName}`}
 				>
-					{showLockIcon && <Lock className="h-6 w-6 mr-1 inline" />}
-					{currentHandle && editablePageSlug && (
-						<div className="ml-2">
-							<Link
-								href={`/user/${currentHandle}/page/${editablePageSlug}/edit`}
-							>
-								<SquarePen className="w-5 h-5" />
-							</Link>
-						</div>
-					)}
 					{segmentBundle.segment.text}
 				</span>
 			)}

--- a/next/src/app/[locale]/_components/segment-and-translation-section/client.tsx
+++ b/next/src/app/[locale]/_components/segment-and-translation-section/client.tsx
@@ -7,12 +7,14 @@ interface SegmentAndTranslationSectionProps {
 	segmentBundle: SegmentBundle;
 	segmentTextClassName?: string;
 	currentHandle?: string;
+	interactive?: boolean;
 }
 
 export function SegmentAndTranslationSection({
 	segmentBundle,
 	segmentTextClassName,
 	currentHandle,
+	interactive = true,
 }: SegmentAndTranslationSectionProps) {
 	const { mode } = useDisplay();
 	return (

--- a/next/src/app/[locale]/_components/segment-and-translation-section/translation-section.tsx
+++ b/next/src/app/[locale]/_components/segment-and-translation-section/translation-section.tsx
@@ -9,11 +9,13 @@ import { VoteButtons } from "./vote-buttons/client";
 interface TranslationSectionProps {
 	segmentBundle: SegmentBundle;
 	currentHandle: string | undefined;
+	interactive?: boolean;
 }
 
 export function TranslationSection({
 	segmentBundle,
 	currentHandle,
+	interactive = true,
 }: TranslationSectionProps) {
 	const [isSelected, setIsSelected] = useState(false);
 	const { best } = segmentBundle;
@@ -37,7 +39,7 @@ export function TranslationSection({
 			>
 				{sanitizedAndParsedText}
 			</span>
-			{isSelected && (
+			{isSelected && interactive && (
 				<>
 					<span className="flex items-center justify-end gap-2">
 						<Link href={`/user/${best.user.handle}`} className="!no-underline">

--- a/next/src/app/[locale]/_components/translate-action-section/locale-selector/client.test.tsx
+++ b/next/src/app/[locale]/_components/translate-action-section/locale-selector/client.test.tsx
@@ -115,7 +115,7 @@ describe("LocaleSelector", () => {
 		await user.click(button);
 
 		// "French" の選択肢が表示されるはず
-		const frenchOption = screen.getByText("français");
+		const frenchOption = screen.getByText("Français");
 		await user.click(frenchOption);
 
 		// handleLocaleChange により router.push が呼ばれることを検証


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds an edit button to the SubHeader component and introduces an interactive property to control editing functionality across different page contexts.

- Moved the edit button from individual segments to the SubHeader component for a more consistent UI experience.
- Added an `interactive` property to SegmentAndTranslationSection to control whether editing/voting UI should be displayed.
- Disabled interactive features in list views by setting `interactive={false}` in page and project lists.
- Implemented conditional rendering of the edit button based on whether the current user is the owner of the content.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

Introduce an edit button in the SubHeader component, enabling users to edit based on their handle. Additionally, implement interactive properties to control section behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an edit button to the page header for users viewing their own pages, allowing quick access to edit functionality.

- **Improvements**
  - Interactive translation and segment controls can now be disabled in certain list views, streamlining the display and reducing unnecessary UI elements.
  - Updated translation and segment sections to better distinguish between interactive and non-interactive contexts.

- **Refactor**
  - Simplified segment and translation section components by removing unused lock icon and edit link elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->