### PR TITLE
Twitterリンクの処理を改善し、インライン要素としてのXノードを追加しました

### DIFF
--- a/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/parsed-content.tsx
+++ b/next/src/app/[locale]/(common-layout)/user/[handle]/page/[slug]/_components/parsed-content.tsx
@@ -38,17 +38,23 @@ export function ParsedContent({
 			/* ---------- X (旧 Twitter) ポスト ---------- */
 			if (
 				domNode.type === "tag" &&
-				domNode.name === "div" &&
-				domNode.attribs["data-type"] === "x"
+				domNode.name === "a" &&
+				(domNode.attribs.href?.includes("twitter.com") ||
+					domNode.attribs.href?.includes("x.com"))
 			) {
-				const xId = domNode.attribs.xid;
-				if (!xId) return null;
-				return (
-					<div data-type="x" data-x-id={xId} className="not-prose">
-						<XPost id={xId} />
-					</div>
-				);
+				// Extract the status ID from the URL
+				const url = domNode.attribs.href;
+				const match = url.match(/status\/(\d+)/);
+				if (match?.[1]) {
+					const statusId = match[1];
+					return (
+						<div data-type="x" data-x-id={statusId} className="not-prose">
+							<XPost id={statusId} />
+						</div>
+					);
+				}
 			}
+
 			// セグメントの翻訳が存在する場合は、セグメントの翻訳を表示
 			if (domNode.type === "tag" && domNode.attribs["data-number-id"]) {
 				const number = Number(domNode.attribs["data-number-id"]);

--- a/next/src/app/[locale]/(edit-layout)/user/[handle]/page/[slug]/edit/_components/editor/extensions/x-embed.ts
+++ b/next/src/app/[locale]/(edit-layout)/user/[handle]/page/[slug]/edit/_components/editor/extensions/x-embed.ts
@@ -4,41 +4,50 @@ import XView from "./x-view";
 
 export const X = Node.create({
 	name: "x",
-	group: "block",
+	inline: true, // ← ここを追加
+	group: "inline", // ← インライングループに
 	atom: true,
 
-	/* ----- attrs ----- */
 	addAttributes() {
 		return {
 			xId: {
-				default: "",
-				render: (value: string) => ({ "data-x-id": value }), // 保存: data-x-id
-				parseHTML: (el) => el.getAttribute("xid"), // 読込: data-x-id
+				default: null,
+				parseHTML: (el) => el.getAttribute("data-x-id"),
+				renderHTML: (attrs) => ({
+					href: `https://x.com/i/web/status/${attrs.xId}`,
+					target: "_blank",
+					rel: "noopener noreferrer",
+				}),
 			},
 		};
 	},
 
-	/* ----- HTML <-> Node ----- */
+	/* 初期 HTML から a タグを拾う */
 	parseHTML() {
-		return [{ tag: "div[data-type='x']" }];
-	},
-	renderHTML({ HTMLAttributes }) {
 		return [
-			"div",
-			mergeAttributes({ "data-type": "x" }, HTMLAttributes), // 先に固定属性
+			{
+				tag: "a[href]",
+				priority: 1000, // ← Link より先に走るよう念押し
+				getAttrs: (dom) => {
+					const href = (dom as HTMLAnchorElement).href;
+
+					const id = href.match(/status\/(\d+)/)?.[1];
+					return id ? { xId: id } : false;
+				},
+			},
 		];
 	},
-
-	/* ----- NodeView ----- */
-	addNodeView() {
-		return ReactNodeViewRenderer(XView);
+	renderHTML({ HTMLAttributes }) {
+		return ["a", mergeAttributes(HTMLAttributes)];
 	},
 
-	/* ----- PasteRule ----- */
+	addNodeView() {
+		return ReactNodeViewRenderer(XView); // ← ここで Tweet を描画
+	},
+
 	addPasteRules() {
 		const re =
 			/https?:\/\/(?:www\.)?(?:twitter\.com|x\.com)\/[^/]+\/status(?:es)?\/(\d+)/gi;
-
 		return [
 			new PasteRule({
 				find: re,


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Improves Twitter/X link handling by converting X nodes to inline elements and enhancing automatic detection of Twitter/X URLs in both the editor and rendered content.

- Changed X node from `block` to `inline` element in `x-embed.ts` to better integrate with surrounding text.
- Enhanced link detection to automatically recognize both Twitter and X.com URLs in the editor.
- Updated `parsed-content.tsx` to extract status IDs from Twitter/X links and render them as embedded posts.
- Added higher priority (1000) to X node parsing to ensure it takes precedence over regular link handling.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved embedding of X (formerly Twitter) posts by automatically detecting and displaying tweets from pasted or linked URLs.
- **Style**
	- Embedded tweets now appear as inline links within content, providing a more seamless reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->