### PR TITLE
Fix icon comment

### DIFF
--- a/next/src/app/[locale]/_components/header/translate-action-section/locale-selector/lib/type-Icon.client.tsx
+++ b/next/src/app/[locale]/_components/header/translate-action-section/locale-selector/lib/type-Icon.client.tsx
@@ -6,7 +6,7 @@ import type { LocaleStatus } from "./build-locale-options";
  * ───────────────────────────────────────────
  *  source       : 原文                     → FileText
  *  translated   : 既に翻訳がある           → Languages
- *  untranslated : サポート対象だが未翻訳   → FileQuestion
+ *  untranslated : サポート対象だが未翻訳   → FileX
  */
 export function TypeIcon({ status }: { status: LocaleStatus }) {
 	switch (status) {


### PR DESCRIPTION
## Summary
- correct comment for untranslated icon

## Testing
- `npm run check` *(fails: bunx not found)*