### PR TITLE
Refactor editor integration tests and fix editorProps merging issue

### DIFF
--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-config-integration.test.ts
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-config-integration.test.ts
@@ -9,9 +9,13 @@ import { configureEditor } from "./editor-config";
 /**
  * 実際のエディタ統合をテストするためのモック
  */
-function testEditorIntegration(defaultValue: string, placeholder: string, className: string) {
+function testEditorIntegration(
+	defaultValue: string,
+	placeholder: string,
+	className: string,
+) {
 	const baseConfig = configureEditor(defaultValue, placeholder);
-	
+
 	// これが実際のeditor.tsxで行われている処理をシミュレート
 	// BUG VERSION: editorPropsを上書きしてしまう
 	const editorConfig = {
@@ -23,16 +27,20 @@ function testEditorIntegration(defaultValue: string, placeholder: string, classN
 			},
 		},
 	};
-	
+
 	return editorConfig;
 }
 
 /**
  * 修正版のエディタ統合をテストするためのモック
  */
-function testEditorIntegrationFixed(defaultValue: string, placeholder: string, className: string) {
+function testEditorIntegrationFixed(
+	defaultValue: string,
+	placeholder: string,
+	className: string,
+) {
 	const baseConfig = configureEditor(defaultValue, placeholder);
-	
+
 	// FIXED VERSION: editorPropsをマージする
 	const editorConfig = {
 		...baseConfig,
@@ -45,14 +53,14 @@ function testEditorIntegrationFixed(defaultValue: string, placeholder: string, c
 			},
 		},
 	};
-	
+
 	return editorConfig;
 }
 
 describe("Editor Configuration Integration (CSS-safe)", () => {
 	it("should preserve transformPastedHTML in configureEditor output", () => {
 		const config = configureEditor("", "Test placeholder");
-		
+
 		// configureEditorがtransformPastedHTMLを含むことを確認
 		expect(config.editorProps).toBeDefined();
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
@@ -62,10 +70,10 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 	it("should preserve transformPastedHTML function in editor configuration", () => {
 		// configureEditorの設定をテスト
 		const config = configureEditor("", "placeholder");
-		
+
 		// transformPastedHTMLが関数として存在することを確認
 		expect(config.editorProps?.transformPastedHTML).toBeTypeOf("function");
-		
+
 		// transformPastedHTMLの動作をテスト
 		const transformFn = config.editorProps?.transformPastedHTML;
 		if (transformFn) {
@@ -76,12 +84,12 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 
 	it("should merge editorProps correctly without overriding", () => {
 		const config = configureEditor("", "placeholder");
-		
+
 		// configureEditorで設定された属性を確認
 		expect(config.editorProps?.attributes).toEqual({
 			class: "focus:outline-hidden",
 		});
-		
+
 		// transformPastedHTMLも含まれることを確認
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
 	});
@@ -89,30 +97,36 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 	it("should handle complex paste scenarios", () => {
 		const config = configureEditor("", "placeholder");
 		const transformFn = config.editorProps?.transformPastedHTML;
-		
+
 		if (transformFn) {
 			// 単一行
 			expect(transformFn("Single line")).toBe("<p>Single line</p>");
-			
+
 			// 改行1つ
 			expect(transformFn("Line 1\nLine 2")).toBe("<p>Line 1<br>Line 2</p>");
-			
+
 			// 改行2つ（段落分割）
-			expect(transformFn("Para 1\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
-			
+			expect(transformFn("Para 1\n\nPara 2")).toBe(
+				"<p>Para 1</p><p>Para 2</p>",
+			);
+
 			// 改行3つ（段落分割）
-			expect(transformFn("Para 1\n\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
-			
+			expect(transformFn("Para 1\n\n\nPara 2")).toBe(
+				"<p>Para 1</p><p>Para 2</p>",
+			);
+
 			// 競馬のテストケース
-			const testText = "競馬でボロ負けした帰りに宝くじ買ったら当たりました\n100円→500円のしょぼいのですが\n競馬やめよかな\n\n感想書きます";
-			const expectedResult = "<p>競馬でボロ負けした帰りに宝くじ買ったら当たりました<br>100円→500円のしょぼいのですが<br>競馬やめよかな</p><p>感想書きます</p>";
+			const testText =
+				"競馬でボロ負けした帰りに宝くじ買ったら当たりました\n100円→500円のしょぼいのですが\n競馬やめよかな\n\n感想書きます";
+			const expectedResult =
+				"<p>競馬でボロ負けした帰りに宝くじ買ったら当たりました<br>100円→500円のしょぼいのですが<br>競馬やめよかな</p><p>感想書きます</p>";
 			expect(transformFn(testText)).toBe(expectedResult);
 		}
 	});
 
 	it("should include all required extensions", () => {
 		const config = configureEditor("", "placeholder");
-		
+
 		// 拡張機能が含まれることを確認
 		expect(config.extensions).toBeDefined();
 		expect(Array.isArray(config.extensions)).toBe(true);
@@ -122,7 +136,7 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 	it("should preserve initial content", () => {
 		const initialContent = "<p>Test content</p>";
 		const config = configureEditor(initialContent, "placeholder");
-		
+
 		expect(config.content).toBe(initialContent);
 	});
 
@@ -132,20 +146,20 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 	 */
 	it("should detect editorProps override bug", () => {
 		const config = configureEditor("", "placeholder");
-		
+
 		// この設定が editor.tsx で上書きされないことを確認
 		// 実際のバグでは、この設定がeditor.tsxでattributesだけに上書きされていた
-		
+
 		// 1. configureEditorはtransformPastedHTMLを含む
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
-		
+
 		// 2. attributesも含む
 		expect(config.editorProps?.attributes).toBeDefined();
-		
+
 		// 3. 両方が共存している（これが重要）
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
 		expect(config.editorProps?.attributes).toBeDefined();
-		
+
 		// このテストがあれば、editor.tsxでeditorPropsを上書きした時に
 		// transformPastedHTMLが消えることを検出できた
 	});
@@ -157,18 +171,24 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 	it("should catch the actual editorProps override bug", () => {
 		// バグ版：editorPropsを上書きしてしまう
 		const buggyConfig = testEditorIntegration("", "placeholder", "test-class");
-		
+
 		// バグ版では transformPastedHTML が含まれていないことを確認
-		expect("transformPastedHTML" in (buggyConfig.editorProps || {})).toBe(false);
+		expect("transformPastedHTML" in (buggyConfig.editorProps || {})).toBe(
+			false,
+		);
 		expect(buggyConfig.editorProps?.attributes).toBeDefined();
-		
+
 		// 修正版：editorPropsをマージする
-		const fixedConfig = testEditorIntegrationFixed("", "placeholder", "test-class");
-		
+		const fixedConfig = testEditorIntegrationFixed(
+			"",
+			"placeholder",
+			"test-class",
+		);
+
 		// transformPastedHTMLが保持されることを確認（これが正しい）
 		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
 		expect(fixedConfig.editorProps?.attributes).toBeDefined();
-		
+
 		// attributesもマージされることを確認
 		expect(fixedConfig.editorProps?.attributes).toEqual({
 			class: "test-class",
@@ -182,13 +202,19 @@ describe("Editor Configuration Integration (CSS-safe)", () => {
 	 */
 	it("should verify editor.tsx implementation is now fixed", () => {
 		// 修正後の実装をシミュレート
-		const fixedConfig = testEditorIntegrationFixed("", "placeholder", "test-class");
-		
+		const fixedConfig = testEditorIntegrationFixed(
+			"",
+			"placeholder",
+			"test-class",
+		);
+
 		// transformPastedHTMLが保持されていることを確認（修正済み）
 		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
-		
+
 		// attributesも正しくマージされていることを確認
-		expect(fixedConfig.editorProps?.attributes?.["data-testid"]).toBe("tiptap-editor");
+		expect(fixedConfig.editorProps?.attributes?.["data-testid"]).toBe(
+			"tiptap-editor",
+		);
 		expect(fixedConfig.editorProps?.attributes?.class).toBe("test-class");
 	});
 });

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-config-integration.test.ts
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-config-integration.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { configureEditor } from "./editor-config";
+
+/**
+ * エディタ設定の統合テスト（純粋なconfigureEditor関数のみテスト）
+ * react-tweetやその他のコンポーネントを避けてCSSエラーを回避
+ */
+
+/**
+ * 実際のエディタ統合をテストするためのモック
+ */
+function testEditorIntegration(defaultValue: string, placeholder: string, className: string) {
+	const baseConfig = configureEditor(defaultValue, placeholder);
+	
+	// これが実際のeditor.tsxで行われている処理をシミュレート
+	// BUG VERSION: editorPropsを上書きしてしまう
+	const editorConfig = {
+		...baseConfig,
+		editorProps: {
+			attributes: {
+				"data-testid": "tiptap-editor",
+				class: className,
+			},
+		},
+	};
+	
+	return editorConfig;
+}
+
+/**
+ * 修正版のエディタ統合をテストするためのモック
+ */
+function testEditorIntegrationFixed(defaultValue: string, placeholder: string, className: string) {
+	const baseConfig = configureEditor(defaultValue, placeholder);
+	
+	// FIXED VERSION: editorPropsをマージする
+	const editorConfig = {
+		...baseConfig,
+		editorProps: {
+			...baseConfig.editorProps,
+			attributes: {
+				...baseConfig.editorProps?.attributes,
+				"data-testid": "tiptap-editor",
+				class: className,
+			},
+		},
+	};
+	
+	return editorConfig;
+}
+
+describe("Editor Configuration Integration (CSS-safe)", () => {
+	it("should preserve transformPastedHTML in configureEditor output", () => {
+		const config = configureEditor("", "Test placeholder");
+		
+		// configureEditorがtransformPastedHTMLを含むことを確認
+		expect(config.editorProps).toBeDefined();
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+		expect(typeof config.editorProps?.transformPastedHTML).toBe("function");
+	});
+
+	it("should preserve transformPastedHTML function in editor configuration", () => {
+		// configureEditorの設定をテスト
+		const config = configureEditor("", "placeholder");
+		
+		// transformPastedHTMLが関数として存在することを確認
+		expect(config.editorProps?.transformPastedHTML).toBeTypeOf("function");
+		
+		// transformPastedHTMLの動作をテスト
+		const transformFn = config.editorProps?.transformPastedHTML;
+		if (transformFn) {
+			const result = transformFn("Line 1\nLine 2\n\nLine 3");
+			expect(result).toBe("<p>Line 1<br>Line 2</p><p>Line 3</p>");
+		}
+	});
+
+	it("should merge editorProps correctly without overriding", () => {
+		const config = configureEditor("", "placeholder");
+		
+		// configureEditorで設定された属性を確認
+		expect(config.editorProps?.attributes).toEqual({
+			class: "focus:outline-hidden",
+		});
+		
+		// transformPastedHTMLも含まれることを確認
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+	});
+
+	it("should handle complex paste scenarios", () => {
+		const config = configureEditor("", "placeholder");
+		const transformFn = config.editorProps?.transformPastedHTML;
+		
+		if (transformFn) {
+			// 単一行
+			expect(transformFn("Single line")).toBe("<p>Single line</p>");
+			
+			// 改行1つ
+			expect(transformFn("Line 1\nLine 2")).toBe("<p>Line 1<br>Line 2</p>");
+			
+			// 改行2つ（段落分割）
+			expect(transformFn("Para 1\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
+			
+			// 改行3つ（段落分割）
+			expect(transformFn("Para 1\n\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
+			
+			// 競馬のテストケース
+			const testText = "競馬でボロ負けした帰りに宝くじ買ったら当たりました\n100円→500円のしょぼいのですが\n競馬やめよかな\n\n感想書きます";
+			const expectedResult = "<p>競馬でボロ負けした帰りに宝くじ買ったら当たりました<br>100円→500円のしょぼいのですが<br>競馬やめよかな</p><p>感想書きます</p>";
+			expect(transformFn(testText)).toBe(expectedResult);
+		}
+	});
+
+	it("should include all required extensions", () => {
+		const config = configureEditor("", "placeholder");
+		
+		// 拡張機能が含まれることを確認
+		expect(config.extensions).toBeDefined();
+		expect(Array.isArray(config.extensions)).toBe(true);
+		expect(config.extensions.length).toBeGreaterThan(0);
+	});
+
+	it("should preserve initial content", () => {
+		const initialContent = "<p>Test content</p>";
+		const config = configureEditor(initialContent, "placeholder");
+		
+		expect(config.content).toBe(initialContent);
+	});
+
+	/**
+	 * これが今回修正した重要なテスト
+	 * editor.tsxでeditorPropsが上書きされてtransformPastedHTMLが消える問題をキャッチする
+	 */
+	it("should detect editorProps override bug", () => {
+		const config = configureEditor("", "placeholder");
+		
+		// この設定が editor.tsx で上書きされないことを確認
+		// 実際のバグでは、この設定がeditor.tsxでattributesだけに上書きされていた
+		
+		// 1. configureEditorはtransformPastedHTMLを含む
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+		
+		// 2. attributesも含む
+		expect(config.editorProps?.attributes).toBeDefined();
+		
+		// 3. 両方が共存している（これが重要）
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+		expect(config.editorProps?.attributes).toBeDefined();
+		
+		// このテストがあれば、editor.tsxでeditorPropsを上書きした時に
+		// transformPastedHTMLが消えることを検出できた
+	});
+
+	/**
+	 * 実際のeditor.tsxでの統合をテスト
+	 * バグ版と修正版を比較してテストが機能することを確認
+	 */
+	it("should catch the actual editorProps override bug", () => {
+		// バグ版：editorPropsを上書きしてしまう
+		const buggyConfig = testEditorIntegration("", "placeholder", "test-class");
+		
+		// バグ版では transformPastedHTML が含まれていないことを確認
+		expect("transformPastedHTML" in (buggyConfig.editorProps || {})).toBe(false);
+		expect(buggyConfig.editorProps?.attributes).toBeDefined();
+		
+		// 修正版：editorPropsをマージする
+		const fixedConfig = testEditorIntegrationFixed("", "placeholder", "test-class");
+		
+		// transformPastedHTMLが保持されることを確認（これが正しい）
+		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
+		expect(fixedConfig.editorProps?.attributes).toBeDefined();
+		
+		// attributesもマージされることを確認
+		expect(fixedConfig.editorProps?.attributes).toEqual({
+			class: "test-class",
+			"data-testid": "tiptap-editor",
+		});
+	});
+
+	/**
+	 * 修正されたeditor.tsxの実装をテスト
+	 * バグが修正されたことを確認
+	 */
+	it("should verify editor.tsx implementation is now fixed", () => {
+		// 修正後の実装をシミュレート
+		const fixedConfig = testEditorIntegrationFixed("", "placeholder", "test-class");
+		
+		// transformPastedHTMLが保持されていることを確認（修正済み）
+		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
+		
+		// attributesも正しくマージされていることを確認
+		expect(fixedConfig.editorProps?.attributes?.["data-testid"]).toBe("tiptap-editor");
+		expect(fixedConfig.editorProps?.attributes?.class).toBe("test-class");
+	});
+});

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-integration.test.tsx
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-integration.test.tsx
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { configureEditor } from "./editor-config";
+
+/**
+ * 現在のeditor.tsxの実装をシミュレート（バグありバージョン）
+ */
+function simulateCurrentEditorImplementation(defaultValue: string, placeholder: string, className: string) {
+	const baseConfig = configureEditor(defaultValue, placeholder);
+	
+	// 現在のeditor.tsxの実装：editorPropsを完全に上書き
+	const editorConfig = {
+		...baseConfig,
+		editorProps: {
+			attributes: {
+				"data-testid": "tiptap-editor",
+				class: className,
+			},
+		},
+	};
+	
+	return editorConfig;
+}
+
+/**
+ * 修正されたエディタ統合をテストするためのモック
+ */
+function simulateFixedEditorImplementation(defaultValue: string, placeholder: string, className: string) {
+	const baseConfig = configureEditor(defaultValue, placeholder);
+	
+	// 修正版：editorPropsをマージする
+	const editorConfig = {
+		...baseConfig,
+		editorProps: {
+			...baseConfig.editorProps,
+			attributes: {
+				...baseConfig.editorProps?.attributes,
+				"data-testid": "tiptap-editor",
+				class: className,
+			},
+		},
+	};
+	
+	return editorConfig;
+}
+
+describe("Editor Configuration Integration", () => {
+	it("should verify that editor.tsx now correctly preserves transformPastedHTML", () => {
+		// editor.tsxの修正された実装をシミュレート
+		const baseConfig = configureEditor("", "Test placeholder");
+		
+		// 修正されたeditor.tsxの実装をシミュレート
+		const editorConfig = {
+			...baseConfig,
+			editorProps: {
+				...baseConfig.editorProps,
+				attributes: {
+					...baseConfig.editorProps?.attributes,
+					"data-testid": "tiptap-editor",
+					class: "test-class",
+				},
+			},
+		};
+		
+		// 修正された実装では transformPastedHTML が保持されている
+		expect(editorConfig.editorProps?.transformPastedHTML).toBeDefined();
+		expect(typeof editorConfig.editorProps?.transformPastedHTML).toBe("function");
+		
+		// ペースト機能も正しく動作する
+		const transformFn = editorConfig.editorProps?.transformPastedHTML;
+		if (transformFn) {
+			expect(transformFn("Line 1\n\nLine 2")).toBe("<p>Line 1</p><p>Line 2</p>");
+		}
+	});
+	it("should preserve transformPastedHTML in configureEditor output", () => {
+		const config = configureEditor("", "Test placeholder");
+		
+		// configureEditorがtransformPastedHTMLを含むことを確認
+		expect(config.editorProps).toBeDefined();
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+		expect(typeof config.editorProps?.transformPastedHTML).toBe("function");
+	});
+
+	it("should preserve transformPastedHTML function in editor configuration", () => {
+		// configureEditorの設定をテスト
+		const config = configureEditor("", "placeholder");
+		
+		// transformPastedHTMLが関数として存在することを確認
+		expect(config.editorProps?.transformPastedHTML).toBeTypeOf("function");
+		
+		// transformPastedHTMLの動作をテスト
+		const transformFn = config.editorProps?.transformPastedHTML;
+		if (transformFn) {
+			const result = transformFn("Line 1\nLine 2\n\nLine 3");
+			expect(result).toBe("<p>Line 1<br>Line 2</p><p>Line 3</p>");
+		}
+	});
+
+	it("should merge editorProps correctly without overriding", () => {
+		const config = configureEditor("", "placeholder");
+		
+		// configureEditorで設定された属性を確認
+		expect(config.editorProps?.attributes).toEqual({
+			class: "focus:outline-hidden",
+		});
+		
+		// transformPastedHTMLも含まれることを確認
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+	});
+
+	it("should handle complex paste scenarios", () => {
+		const config = configureEditor("", "placeholder");
+		const transformFn = config.editorProps?.transformPastedHTML;
+		
+		if (transformFn) {
+			// 単一行
+			expect(transformFn("Single line")).toBe("<p>Single line</p>");
+			
+			// 改行1つ
+			expect(transformFn("Line 1\nLine 2")).toBe("<p>Line 1<br>Line 2</p>");
+			
+			// 改行2つ（段落分割）
+			expect(transformFn("Para 1\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
+			
+			// 改行3つ（段落分割）
+			expect(transformFn("Para 1\n\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
+			
+			// 競馬のテストケース
+			const testText = "競馬でボロ負けした帰りに宝くじ買ったら当たりました\n100円→500円のしょぼいのですが\n競馬やめよかな\n\n感想書きます";
+			const expectedResult = "<p>競馬でボロ負けした帰りに宝くじ買ったら当たりました<br>100円→500円のしょぼいのですが<br>競馬やめよかな</p><p>感想書きます</p>";
+			expect(transformFn(testText)).toBe(expectedResult);
+		}
+	});
+
+	it("should include all required extensions", () => {
+		const config = configureEditor("", "placeholder");
+		
+		// 拡張機能が含まれることを確認
+		expect(config.extensions).toBeDefined();
+		expect(Array.isArray(config.extensions)).toBe(true);
+		expect(config.extensions.length).toBeGreaterThan(0);
+	});
+
+	it("should preserve initial content", () => {
+		const initialContent = "<p>Test content</p>";
+		const config = configureEditor(initialContent, "placeholder");
+		
+		expect(config.content).toBe(initialContent);
+	});
+
+	/**
+	 * これが今回修正した重要なテスト
+	 * editor.tsxでeditorPropsが上書きされてtransformPastedHTMLが消える問題をキャッチする
+	 */
+	it("should detect editorProps override bug", () => {
+		const config = configureEditor("", "placeholder");
+		
+		// この設定が editor.tsx で上書きされないことを確認
+		// 実際のバグでは、この設定がeditor.tsxでattributesだけに上書きされていた
+		
+		// 1. configureEditorはtransformPastedHTMLを含む
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+		
+		// 2. attributesも含む
+		expect(config.editorProps?.attributes).toBeDefined();
+		
+		// 3. 両方が共存している（これが重要）
+		expect(config.editorProps?.transformPastedHTML).toBeDefined();
+		expect(config.editorProps?.attributes).toBeDefined();
+		
+		// このテストがあれば、editor.tsxでeditorPropsを上書きした時に
+		// transformPastedHTMLが消えることを検出できた
+	});
+
+
+	/**
+	 * 実際のeditor.tsxでの統合をテスト
+	 * バグ版と修正版を比較してテストが機能することを確認
+	 */
+	it("should detect that current editor.tsx implementation loses transformPastedHTML", () => {
+		// 現在のeditor.tsx実装：editorPropsを完全に上書き
+		const currentConfig = simulateCurrentEditorImplementation("", "placeholder", "test-class");
+		
+		// 現在の実装では transformPastedHTML が失われることを確認
+		expect("transformPastedHTML" in (currentConfig.editorProps || {})).toBe(false);
+		expect(currentConfig.editorProps?.attributes).toBeDefined();
+		
+		// 修正版：editorPropsをマージする
+		const fixedConfig = simulateFixedEditorImplementation("", "placeholder", "test-class");
+		
+		// 修正版では transformPastedHTML が保持されることを確認
+		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
+		expect(fixedConfig.editorProps?.attributes).toBeDefined();
+		
+		// attributesもマージされることを確認
+		expect(fixedConfig.editorProps?.attributes).toEqual({
+			class: "test-class",
+			"data-testid": "tiptap-editor",
+		});
+	});
+
+	it("should verify that current editor.tsx implementation breaks paste functionality", () => {
+		// 現在の実装での paste 処理をテスト
+		const currentConfig = simulateCurrentEditorImplementation("", "placeholder", "test-class");
+		
+		// transformPastedHTML が存在しないため、paste時の改行処理が動作しない
+		expect(currentConfig.editorProps?.transformPastedHTML).toBeUndefined();
+		
+		// 修正版では paste 処理が動作する
+		const fixedConfig = simulateFixedEditorImplementation("", "placeholder", "test-class");
+		const transformFn = fixedConfig.editorProps?.transformPastedHTML;
+		
+		if (transformFn) {
+			// paste機能のテスト
+			const testInput = "Line 1\nLine 2\n\nLine 3";
+			const expectedOutput = "<p>Line 1<br>Line 2</p><p>Line 3</p>";
+			expect(transformFn(testInput)).toBe(expectedOutput);
+		}
+	});
+
+	/**
+	 * 修正されたeditor.tsxの実装をテスト
+	 * バグが修正されたことを確認
+	 */
+	it("should demonstrate how to fix editor.tsx to preserve transformPastedHTML", () => {
+		// 修正後の実装をシミュレート
+		const fixedConfig = simulateFixedEditorImplementation("", "placeholder", "test-class");
+		
+		// transformPastedHTMLが保持されていることを確認（修正済み）
+		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
+		
+		// attributesも正しくマージされていることを確認
+		expect(fixedConfig.editorProps?.attributes?.["data-testid"]).toBe("tiptap-editor");
+		expect(fixedConfig.editorProps?.attributes?.class).toBe("test-class");
+		
+		// paste機能も動作することを確認
+		const transformFn = fixedConfig.editorProps?.transformPastedHTML;
+		if (transformFn) {
+			expect(transformFn("test\n\nline")).toBe("<p>test</p><p>line</p>");
+		}
+	});
+});

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-integration.test.tsx
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-integration.test.tsx
@@ -4,9 +4,13 @@ import { configureEditor } from "./editor-config";
 /**
  * 現在のeditor.tsxの実装をシミュレート（バグありバージョン）
  */
-function simulateCurrentEditorImplementation(defaultValue: string, placeholder: string, className: string) {
+function simulateCurrentEditorImplementation(
+	defaultValue: string,
+	placeholder: string,
+	className: string,
+) {
 	const baseConfig = configureEditor(defaultValue, placeholder);
-	
+
 	// 現在のeditor.tsxの実装：editorPropsを完全に上書き
 	const editorConfig = {
 		...baseConfig,
@@ -17,16 +21,20 @@ function simulateCurrentEditorImplementation(defaultValue: string, placeholder: 
 			},
 		},
 	};
-	
+
 	return editorConfig;
 }
 
 /**
  * 修正されたエディタ統合をテストするためのモック
  */
-function simulateFixedEditorImplementation(defaultValue: string, placeholder: string, className: string) {
+function simulateFixedEditorImplementation(
+	defaultValue: string,
+	placeholder: string,
+	className: string,
+) {
 	const baseConfig = configureEditor(defaultValue, placeholder);
-	
+
 	// 修正版：editorPropsをマージする
 	const editorConfig = {
 		...baseConfig,
@@ -39,7 +47,7 @@ function simulateFixedEditorImplementation(defaultValue: string, placeholder: st
 			},
 		},
 	};
-	
+
 	return editorConfig;
 }
 
@@ -47,7 +55,7 @@ describe("Editor Configuration Integration", () => {
 	it("should verify that editor.tsx now correctly preserves transformPastedHTML", () => {
 		// editor.tsxの修正された実装をシミュレート
 		const baseConfig = configureEditor("", "Test placeholder");
-		
+
 		// 修正されたeditor.tsxの実装をシミュレート
 		const editorConfig = {
 			...baseConfig,
@@ -60,20 +68,24 @@ describe("Editor Configuration Integration", () => {
 				},
 			},
 		};
-		
+
 		// 修正された実装では transformPastedHTML が保持されている
 		expect(editorConfig.editorProps?.transformPastedHTML).toBeDefined();
-		expect(typeof editorConfig.editorProps?.transformPastedHTML).toBe("function");
-		
+		expect(typeof editorConfig.editorProps?.transformPastedHTML).toBe(
+			"function",
+		);
+
 		// ペースト機能も正しく動作する
 		const transformFn = editorConfig.editorProps?.transformPastedHTML;
 		if (transformFn) {
-			expect(transformFn("Line 1\n\nLine 2")).toBe("<p>Line 1</p><p>Line 2</p>");
+			expect(transformFn("Line 1\n\nLine 2")).toBe(
+				"<p>Line 1</p><p>Line 2</p>",
+			);
 		}
 	});
 	it("should preserve transformPastedHTML in configureEditor output", () => {
 		const config = configureEditor("", "Test placeholder");
-		
+
 		// configureEditorがtransformPastedHTMLを含むことを確認
 		expect(config.editorProps).toBeDefined();
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
@@ -83,10 +95,10 @@ describe("Editor Configuration Integration", () => {
 	it("should preserve transformPastedHTML function in editor configuration", () => {
 		// configureEditorの設定をテスト
 		const config = configureEditor("", "placeholder");
-		
+
 		// transformPastedHTMLが関数として存在することを確認
 		expect(config.editorProps?.transformPastedHTML).toBeTypeOf("function");
-		
+
 		// transformPastedHTMLの動作をテスト
 		const transformFn = config.editorProps?.transformPastedHTML;
 		if (transformFn) {
@@ -97,12 +109,12 @@ describe("Editor Configuration Integration", () => {
 
 	it("should merge editorProps correctly without overriding", () => {
 		const config = configureEditor("", "placeholder");
-		
+
 		// configureEditorで設定された属性を確認
 		expect(config.editorProps?.attributes).toEqual({
 			class: "focus:outline-hidden",
 		});
-		
+
 		// transformPastedHTMLも含まれることを確認
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
 	});
@@ -110,30 +122,36 @@ describe("Editor Configuration Integration", () => {
 	it("should handle complex paste scenarios", () => {
 		const config = configureEditor("", "placeholder");
 		const transformFn = config.editorProps?.transformPastedHTML;
-		
+
 		if (transformFn) {
 			// 単一行
 			expect(transformFn("Single line")).toBe("<p>Single line</p>");
-			
+
 			// 改行1つ
 			expect(transformFn("Line 1\nLine 2")).toBe("<p>Line 1<br>Line 2</p>");
-			
+
 			// 改行2つ（段落分割）
-			expect(transformFn("Para 1\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
-			
+			expect(transformFn("Para 1\n\nPara 2")).toBe(
+				"<p>Para 1</p><p>Para 2</p>",
+			);
+
 			// 改行3つ（段落分割）
-			expect(transformFn("Para 1\n\n\nPara 2")).toBe("<p>Para 1</p><p>Para 2</p>");
-			
+			expect(transformFn("Para 1\n\n\nPara 2")).toBe(
+				"<p>Para 1</p><p>Para 2</p>",
+			);
+
 			// 競馬のテストケース
-			const testText = "競馬でボロ負けした帰りに宝くじ買ったら当たりました\n100円→500円のしょぼいのですが\n競馬やめよかな\n\n感想書きます";
-			const expectedResult = "<p>競馬でボロ負けした帰りに宝くじ買ったら当たりました<br>100円→500円のしょぼいのですが<br>競馬やめよかな</p><p>感想書きます</p>";
+			const testText =
+				"競馬でボロ負けした帰りに宝くじ買ったら当たりました\n100円→500円のしょぼいのですが\n競馬やめよかな\n\n感想書きます";
+			const expectedResult =
+				"<p>競馬でボロ負けした帰りに宝くじ買ったら当たりました<br>100円→500円のしょぼいのですが<br>競馬やめよかな</p><p>感想書きます</p>";
 			expect(transformFn(testText)).toBe(expectedResult);
 		}
 	});
 
 	it("should include all required extensions", () => {
 		const config = configureEditor("", "placeholder");
-		
+
 		// 拡張機能が含まれることを確認
 		expect(config.extensions).toBeDefined();
 		expect(Array.isArray(config.extensions)).toBe(true);
@@ -143,7 +161,7 @@ describe("Editor Configuration Integration", () => {
 	it("should preserve initial content", () => {
 		const initialContent = "<p>Test content</p>";
 		const config = configureEditor(initialContent, "placeholder");
-		
+
 		expect(config.content).toBe(initialContent);
 	});
 
@@ -153,24 +171,23 @@ describe("Editor Configuration Integration", () => {
 	 */
 	it("should detect editorProps override bug", () => {
 		const config = configureEditor("", "placeholder");
-		
+
 		// この設定が editor.tsx で上書きされないことを確認
 		// 実際のバグでは、この設定がeditor.tsxでattributesだけに上書きされていた
-		
+
 		// 1. configureEditorはtransformPastedHTMLを含む
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
-		
+
 		// 2. attributesも含む
 		expect(config.editorProps?.attributes).toBeDefined();
-		
+
 		// 3. 両方が共存している（これが重要）
 		expect(config.editorProps?.transformPastedHTML).toBeDefined();
 		expect(config.editorProps?.attributes).toBeDefined();
-		
+
 		// このテストがあれば、editor.tsxでeditorPropsを上書きした時に
 		// transformPastedHTMLが消えることを検出できた
 	});
-
 
 	/**
 	 * 実際のeditor.tsxでの統合をテスト
@@ -178,19 +195,29 @@ describe("Editor Configuration Integration", () => {
 	 */
 	it("should detect that current editor.tsx implementation loses transformPastedHTML", () => {
 		// 現在のeditor.tsx実装：editorPropsを完全に上書き
-		const currentConfig = simulateCurrentEditorImplementation("", "placeholder", "test-class");
-		
+		const currentConfig = simulateCurrentEditorImplementation(
+			"",
+			"placeholder",
+			"test-class",
+		);
+
 		// 現在の実装では transformPastedHTML が失われることを確認
-		expect("transformPastedHTML" in (currentConfig.editorProps || {})).toBe(false);
+		expect("transformPastedHTML" in (currentConfig.editorProps || {})).toBe(
+			false,
+		);
 		expect(currentConfig.editorProps?.attributes).toBeDefined();
-		
+
 		// 修正版：editorPropsをマージする
-		const fixedConfig = simulateFixedEditorImplementation("", "placeholder", "test-class");
-		
+		const fixedConfig = simulateFixedEditorImplementation(
+			"",
+			"placeholder",
+			"test-class",
+		);
+
 		// 修正版では transformPastedHTML が保持されることを確認
 		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
 		expect(fixedConfig.editorProps?.attributes).toBeDefined();
-		
+
 		// attributesもマージされることを確認
 		expect(fixedConfig.editorProps?.attributes).toEqual({
 			class: "test-class",
@@ -200,15 +227,23 @@ describe("Editor Configuration Integration", () => {
 
 	it("should verify that current editor.tsx implementation breaks paste functionality", () => {
 		// 現在の実装での paste 処理をテスト
-		const currentConfig = simulateCurrentEditorImplementation("", "placeholder", "test-class");
-		
+		const currentConfig = simulateCurrentEditorImplementation(
+			"",
+			"placeholder",
+			"test-class",
+		);
+
 		// transformPastedHTML が存在しないため、paste時の改行処理が動作しない
 		expect(currentConfig.editorProps?.transformPastedHTML).toBeUndefined();
-		
+
 		// 修正版では paste 処理が動作する
-		const fixedConfig = simulateFixedEditorImplementation("", "placeholder", "test-class");
+		const fixedConfig = simulateFixedEditorImplementation(
+			"",
+			"placeholder",
+			"test-class",
+		);
 		const transformFn = fixedConfig.editorProps?.transformPastedHTML;
-		
+
 		if (transformFn) {
 			// paste機能のテスト
 			const testInput = "Line 1\nLine 2\n\nLine 3";
@@ -223,15 +258,21 @@ describe("Editor Configuration Integration", () => {
 	 */
 	it("should demonstrate how to fix editor.tsx to preserve transformPastedHTML", () => {
 		// 修正後の実装をシミュレート
-		const fixedConfig = simulateFixedEditorImplementation("", "placeholder", "test-class");
-		
+		const fixedConfig = simulateFixedEditorImplementation(
+			"",
+			"placeholder",
+			"test-class",
+		);
+
 		// transformPastedHTMLが保持されていることを確認（修正済み）
 		expect(fixedConfig.editorProps?.transformPastedHTML).toBeDefined();
-		
+
 		// attributesも正しくマージされていることを確認
-		expect(fixedConfig.editorProps?.attributes?.["data-testid"]).toBe("tiptap-editor");
+		expect(fixedConfig.editorProps?.attributes?.["data-testid"]).toBe(
+			"tiptap-editor",
+		);
 		expect(fixedConfig.editorProps?.attributes?.class).toBe("test-class");
-		
+
 		// paste機能も動作することを確認
 		const transformFn = fixedConfig.editorProps?.transformPastedHTML;
 		if (transformFn) {

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor.tsx
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor.tsx
@@ -23,8 +23,9 @@ export function Editor({
 	placeholder,
 }: EditorProps) {
 	const editorRef = useRef<HTMLInputElement>(null);
+	const baseConfig = configureEditor(defaultValue, placeholder);
 	const editor = useEditor({
-		...configureEditor(defaultValue, placeholder),
+		...baseConfig,
 		onCreate: ({ editor }) => {
 			if (editorRef.current) {
 				editorRef.current.value = editor.getHTML();
@@ -35,7 +36,9 @@ export function Editor({
 			onEditorUpdate?.(editor);
 		},
 		editorProps: {
+			...baseConfig.editorProps,
 			attributes: {
+				...baseConfig.editorProps?.attributes,
 				"data-testid": "tiptap-editor",
 				class: className,
 			},

--- a/src/app/[locale]/_lib/html-to-mdast-with-segments.test.ts
+++ b/src/app/[locale]/_lib/html-to-mdast-with-segments.test.ts
@@ -196,7 +196,7 @@ describe("htmlToMdastWithSegments", () => {
 		expect(segmentTexts).toContain("Unordered list item 2");
 		expect(segmentTexts).toContain("Ordered list item 1");
 		expect(segmentTexts).toContain("Ordered list item 2");
-		expect(segmentTexts).toContain("Paragraph with Test image embedded image");
+		expect(segmentTexts).toContain("Paragraph with  embedded image");
 		expect(segmentTexts).toContain("Paragraph after horizontal rule");
 
 		// Check MDAST structure for various elements

--- a/src/app/[locale]/_lib/remark-hash-and-segments.test.ts
+++ b/src/app/[locale]/_lib/remark-hash-and-segments.test.ts
@@ -125,5 +125,24 @@ describe("remarkHashAndSegments", () => {
 		expect(texts).toContain("B");
 		// 画像altやURLがsegmentに含まれないこと
 		expect(texts.some((t: string) => t.includes("image.png"))).toBe(false);
+		// alt属性もsegmentに含まれないこと（includeImageAlt: falseの効果）
+		expect(texts.some((t: string) => t.includes("alt"))).toBe(false);
+	});
+
+	it("段落内の画像alt属性は翻訳対象にならない", async () => {
+		const md = "Text with ![important description](image.jpg) inline image.";
+		const file = (await remark()
+			.use(remarkHashAndSegments())
+			.process(md)) as VFile & { data: { segments: SegmentDraft[] } };
+		const texts = (file.data.segments as SegmentDraft[]).map(
+			(s: SegmentDraft) => s.text,
+		);
+		// テキスト部分は含まれる
+		expect(texts.some((t: string) => t.includes("Text with"))).toBe(true);
+		expect(texts.some((t: string) => t.includes("inline image"))).toBe(true);
+		// alt属性は含まれない（includeImageAlt: falseの効果）
+		expect(texts.some((t: string) => t.includes("important description"))).toBe(false);
+		// 画像URLも含まれない
+		expect(texts.some((t: string) => t.includes("image.jpg"))).toBe(false);
 	});
 });

--- a/src/app/[locale]/_lib/remark-hash-and-segments.test.ts
+++ b/src/app/[locale]/_lib/remark-hash-and-segments.test.ts
@@ -141,7 +141,9 @@ describe("remarkHashAndSegments", () => {
 		expect(texts.some((t: string) => t.includes("Text with"))).toBe(true);
 		expect(texts.some((t: string) => t.includes("inline image"))).toBe(true);
 		// alt属性は含まれない（includeImageAlt: falseの効果）
-		expect(texts.some((t: string) => t.includes("important description"))).toBe(false);
+		expect(texts.some((t: string) => t.includes("important description"))).toBe(
+			false,
+		);
 		// 画像URLも含まれない
 		expect(texts.some((t: string) => t.includes("image.jpg"))).toBe(false);
 	});

--- a/src/app/[locale]/_lib/remark-hash-and-segments.ts
+++ b/src/app/[locale]/_lib/remark-hash-and-segments.ts
@@ -79,8 +79,8 @@ export const remarkHashAndSegments =
 					);
 				if (hasNestedBlock) return;
 
-				/* テキスト抽出 */
-				const merged = mdastToString(typedNode).trim();
+				/* テキスト抽出（画像のalt属性は除外） */
+				const merged = mdastToString(typedNode, { includeImageAlt: false }).trim();
 				if (!merged) return;
 
 				/* ハッシュ生成 */

--- a/src/app/[locale]/_lib/remark-hash-and-segments.ts
+++ b/src/app/[locale]/_lib/remark-hash-and-segments.ts
@@ -80,7 +80,9 @@ export const remarkHashAndSegments =
 				if (hasNestedBlock) return;
 
 				/* テキスト抽出（画像のalt属性は除外） */
-				const merged = mdastToString(typedNode, { includeImageAlt: false }).trim();
+				const merged = mdastToString(typedNode, {
+					includeImageAlt: false,
+				}).trim();
 				if (!merged) return;
 
 				/* ハッシュ生成 */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
 		setupFiles: "./vitest.setup.ts",
 		server: {
 			deps: {
-				inline: ["next-auth", "next-intl"],
+				inline: ["next-auth", "next-intl", "react-tweet"],
 			},
 		},
 	},


### PR DESCRIPTION
Refactor the editor integration tests to improve clarity and add tests for detecting the editorProps overwrite bug. Update text extraction to exclude image alt attributes and enhance HTML conversion newline handling.