### PR TITLE
VoteButtons が持つキーを「翻訳 ID・現在のポイント・自分の投票種別」で構成し、

### DIFF
--- a/src/app/[locale]/_components/wrap-segments/translation-section/client.tsx
+++ b/src/app/[locale]/_components/wrap-segments/translation-section/client.tsx
@@ -71,7 +71,11 @@ export function TranslationSection<Tag extends keyof JSX.IntrinsicElements>({
 								by: {best.user.name}
 							</span>
 						</Link>
-						<VoteButtons targetContentType={parentType} translation={best} />
+						<VoteButtons
+							key={`${best.id}-${best.point}-${best.currentUserVote?.isUpvote ?? "null"}`}
+							targetContentType={parentType}
+							translation={best}
+						/>
 					</span>
 					<AddAndVoteTranslations
 						currentHandle={currentHandle}

--- a/src/app/[locale]/_components/wrap-segments/translation-section/translation-list-item/index.tsx
+++ b/src/app/[locale]/_components/wrap-segments/translation-section/translation-list-item/index.tsx
@@ -74,6 +74,7 @@ export function TranslationListItem({
 					</span>
 				</Link>
 				<VoteButtons
+					key={`${translation.id}-${translation.point}-${translation.currentUserVote?.isUpvote ?? "null"}`}
 					targetContentType={targetContentType}
 					translation={translation}
 				/>


### PR DESCRIPTION
これらが変わったときにコンポーネントを強制的に再マウントするようにしました。これでサーバーから最新の値が届くたびに initialState がリセットされ、
常に正しいポイントが表示されます。