### PR TITLE
ChildPageTreeコンポーネント内でアイコンを▶からChevronRightに変更し、状態に応じた回転アニメーションを追加しました。また、import文の順序を整理しました。これにより、ユーザーインターフェースの視覚的な一貫性が向上しました。

### DIFF
--- a/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/child-page-tree.client.tsx
+++ b/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/child-page-tree.client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
-import useSWR from "swr";
 import { WrapSegmentClient } from "@/app/[locale]/_components/wrap-segments/client";
 import type { PageSummary } from "@/app/[locale]/types";
 import { Link } from "@/i18n/routing";
 import { cn } from "@/lib/utils";
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+import useSWR from "swr";
 
 interface Props {
 	parent: PageSummary;
@@ -62,14 +63,9 @@ export function ChildPageTree({ parent, locale }: Props) {
 			onToggle={(e) => setIsOpen(e.currentTarget.open)}
 		>
 			<summary className="cursor-pointer list-none flex items-center gap-1">
-				<span
-					className={cn(
-						"transition-transform self-start pt-0.5",
-						isOpen && "rotate-90",
-					)}
-				>
-					▶
-				</span>
+				<ChevronRight
+					className={cn("h-5 w-5 transition-transform", isOpen && "rotate-90")}
+				/>
 				<Link className="hover:underline" href={pageLink}>
 					{titleSegment && (
 						<WrapSegmentClient

--- a/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/child-page-tree.client.tsx
+++ b/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/child-page-tree.client.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+import useSWR from "swr";
 import { WrapSegmentClient } from "@/app/[locale]/_components/wrap-segments/client";
 import type { PageSummary } from "@/app/[locale]/types";
 import { Link } from "@/i18n/routing";
 import { cn } from "@/lib/utils";
-import { ChevronRight } from "lucide-react";
-import { useState } from "react";
-import useSWR from "swr";
 
 interface Props {
 	parent: PageSummary;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 折りたたみツリーノードの展開状態を示す矢印を、手動作成から新しいアイコン（ChevronRight）に変更し、視認性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->